### PR TITLE
feat: complete CLI infrastructure (Epic 1) (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,30 @@ Tracks is in **Phase 0 (Foundation)** development. The CLI tool and project scaf
 
 - ✅ Project structure and monorepo setup
 - ✅ Documentation and roadmap
-- 🚧 CLI infrastructure (in progress)
+- ✅ CLI infrastructure (complete - v0.1.0 ready)
+  - Root command with version, help, and global flags
+  - Renderer pattern (Console, JSON, TUI-ready)
+  - Mode detection (TTY, CI, flags, env vars)
+  - Theme system with Lip Gloss styling
+  - Comprehensive test coverage (unit + integration)
+
+**Try it now:**
+
+```bash
+# Clone and build
+git clone https://github.com/anomalousventures/tracks.git
+cd tracks
+make build
+
+# Run CLI
+./bin/tracks version
+./bin/tracks --help
+./bin/tracks --json version  # Machine-readable output
+```
 
 **Coming next:**
 
-- Phase 0: CLI tool with `tracks new` command
+- Phase 0: Complete `tracks new` command implementation
 - Phase 1: Core web layer (routing, handlers, middleware)
 - Phase 2: Database layer (SQLC, migrations)
 - See [Roadmap](#roadmap) for details

--- a/docs/roadmap/phases/0-foundation.md
+++ b/docs/roadmap/phases/0-foundation.md
@@ -8,7 +8,7 @@ This phase establishes the basic CLI tool and project scaffolding capabilities. 
 
 **Target Version:** v0.1.0
 **Estimated Duration:** 2-3 weeks
-**Status:** Not Started
+**Status:** In Progress (Epic 1 Complete)
 
 ## Goals
 
@@ -22,7 +22,7 @@ This phase establishes the basic CLI tool and project scaffolding capabilities. 
 
 This phase has been broken down into 5 epics for implementation:
 
-1. [Epic 1: CLI Infrastructure](./epics/1-cli-infrastructure.md) - Foundation CLI with Cobra, version tracking, help system
+1. ✅ [Epic 1: CLI Infrastructure](./epics/1-cli-infrastructure.md) - Foundation CLI with Cobra, version tracking, help system (COMPLETE)
 2. [Epic 2: Template Engine & Embedding](./epics/2-template-engine.md) - Go embed system, template rendering, variable substitution
 3. [Epic 3: Project Generation](./epics/3-project-generation.md) - `tracks new` command, directory structure, config generation
 4. [Epic 4: Generated Project Tooling](./epics/4-generated-tooling.md) - Makefile, Air config, linting, Docker, CI/CD
@@ -38,10 +38,10 @@ Each epic contains detailed task breakdowns that will become GitHub issues.
 
 **Acceptance Criteria:**
 
-- [ ] `tracks` command exists and runs
-- [ ] `--version` flag works
-- [ ] `--help` provides usage information
-- [ ] Launches TUI when run without arguments
+- [x] `tracks` command exists and runs
+- [x] `--version` flag works
+- [x] `--help` provides usage information
+- [x] Launches TUI when run without arguments (placeholder message until Phase 4)
 
 **PRD Reference:** [Core Architecture - CLI Tool Structure](../../prd/1_core_architecture.md#cli-tool-structure)
 

--- a/docs/roadmap/phases/0-foundation/epics/1-cli-infrastructure.md
+++ b/docs/roadmap/phases/0-foundation/epics/1-cli-infrastructure.md
@@ -65,8 +65,8 @@ The following tasks will become GitHub issues, ordered by dependency:
 19. ✅ **Write unit tests for mode detection and flags** ([#21](https://github.com/anomalousventures/tracks/issues/21))
 20. ✅ **Write unit tests for Renderer implementations** ([#22](https://github.com/anomalousventures/tracks/issues/22))
 21. ✅ **Set up CLI integration test framework** ([#23](https://github.com/anomalousventures/tracks/issues/23) | [PR #41](https://github.com/anomalousventures/tracks/pull/41))
-22. **Wire up --json flag to output JSON for version and help commands** ([#42](https://github.com/anomalousventures/tracks/issues/42))
-23. **Document CLI development workflow and Renderer pattern** ([#24](https://github.com/anomalousventures/tracks/issues/24))
+22. ✅ **Wire up --json flag to output JSON for version and help commands** ([#42](https://github.com/anomalousventures/tracks/issues/42) | [PR #43](https://github.com/anomalousventures/tracks/pull/43))
+23. ✅ **Document CLI development workflow and Renderer pattern** ([#24](https://github.com/anomalousventures/tracks/issues/24))
 
 ## Dependencies
 
@@ -92,23 +92,23 @@ Note: Versions listed are current as of October 2025. Use `go get <package>@late
 
 ## Acceptance Criteria
 
-- [ ] `tracks` command builds successfully on Linux, macOS, and Windows
-- [ ] `tracks --version` displays correct version information
-- [ ] `tracks --help` shows usage information with examples
-- [ ] `tracks` with no arguments shows TUI placeholder message
-- [ ] Renderer interface defined and documented
-- [ ] UIMode detection works (TTY, CI, flags, env vars)
-- [ ] ConsoleRenderer works with Lip Gloss styling
-- [ ] Bubbles progress bar renders in console mode (standalone)
-- [ ] JSONRenderer outputs valid JSON
-- [ ] NO_COLOR env var disables colors
-- [ ] TRACKS_LOG_LEVEL env var controls verbosity
-- [ ] --json flag outputs JSON
-- [ ] --no-color flag disables colors
-- [ ] Theme defined once, used everywhere
-- [ ] Unit tests cover root command, version, and Renderer modes
-- [ ] CI pipeline can build the CLI binary
-- [ ] README documents Renderer pattern and output modes
+- [x] `tracks` command builds successfully on Linux, macOS, and Windows
+- [x] `tracks --version` displays correct version information
+- [x] `tracks --help` shows usage information with examples
+- [x] `tracks` with no arguments shows TUI placeholder message
+- [x] Renderer interface defined and documented
+- [x] UIMode detection works (TTY, CI, flags, env vars)
+- [x] ConsoleRenderer works with Lip Gloss styling
+- [x] Bubbles progress bar renders in console mode (standalone)
+- [x] JSONRenderer outputs valid JSON
+- [x] NO_COLOR env var disables colors
+- [x] TRACKS_LOG_LEVEL env var controls verbosity
+- [x] --json flag outputs JSON
+- [x] --no-color flag disables colors
+- [x] Theme defined once, used everywhere
+- [x] Unit tests cover root command, version, and Renderer modes
+- [x] CI pipeline can build the CLI binary
+- [x] README documents Renderer pattern and output modes
 
 ## Technical Notes
 

--- a/internal/cli/README.md
+++ b/internal/cli/README.md
@@ -1,0 +1,552 @@
+# CLI Infrastructure
+
+This package implements the Tracks CLI tool using Cobra, Viper, and the Charm TUI stack (Lip Gloss, Bubbles, Bubble Tea).
+
+## Architecture Overview
+
+The CLI uses the **Renderer Pattern** to separate business logic from output formatting. Commands produce data, Renderers display it.
+
+```text
+┌─────────────┐
+│   Command   │  Business logic (data gathering, validation)
+└──────┬──────┘
+       │
+       ▼
+┌─────────────┐
+│  Renderer   │  Output formatting (console, JSON, TUI)
+└──────┬──────┘
+       │
+       ▼
+┌─────────────┐
+│   Output    │  stdout/stderr
+└─────────────┘
+```
+
+### Key Components
+
+#### 1. Root Command (`root.go`)
+
+- Defines global flags (`--json`, `--no-color`, `--interactive`, `-v`, `-q`)
+- Manages configuration via Viper and context
+- Creates Renderer instances for commands
+- Handles error flushing
+
+#### 2. Renderer Interface (`renderer/renderer.go`)
+
+Defines how output is displayed:
+
+```go
+type Renderer interface {
+    Title(string)
+    Section(Section)
+    Table(Table)
+    Progress(ProgressSpec) Progress
+    Flush() error
+}
+```
+
+**Implementations:**
+
+- **ConsoleRenderer** - Human-readable, colored output using Lip Gloss
+- **JSONRenderer** - Machine-readable JSON for scripting
+- **TUIRenderer** - Interactive Bubble Tea interface (Phase 4)
+
+#### 3. UI Mode Detection (`ui/mode.go`)
+
+Automatically chooses the right output mode:
+
+```text
+Priority (highest to lowest):
+1. --json flag           → ModeJSON
+2. --interactive flag    → ModeTUI (Phase 4: returns ModeConsole)
+3. CI environment        → ModeConsole
+4. Non-TTY stdout        → ModeConsole
+5. Default (TTY)         → ModeConsole (Phase 4: ModeTUI)
+```
+
+#### 4. Theme System (`ui/theme.go`)
+
+Centralized Lip Gloss styles used by ConsoleRenderer and TUIRenderer:
+
+- **Title** - Bold purple (#7D56F4)
+- **Success** - Green (#04B575)
+- **Error** - Red (#FF4672)
+- **Warning** - Orange (#FFA657)
+- **Muted** - Gray (#626262)
+
+Automatically respects `NO_COLOR` environment variable.
+
+## Usage Examples
+
+### Basic Command Structure
+
+```go
+func myCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:   "mycommand",
+        Short: "Does something useful",
+        Run: func(cmd *cobra.Command, args []string) {
+            // 1. Create renderer
+            r := NewRendererFromCommand(cmd)
+
+            // 2. Produce output
+            r.Title("My Command")
+            r.Section(renderer.Section{
+                Body: "Command completed successfully",
+            })
+
+            // 3. Flush
+            flushRenderer(cmd, r)
+        },
+    }
+}
+```
+
+### Using Tables
+
+```go
+r.Table(renderer.Table{
+    Headers: []string{"Name", "Version", "Status"},
+    Rows: [][]string{
+        {"tracks", "0.1.0", "active"},
+        {"cobra", "1.10.1", "stable"},
+    },
+})
+```
+
+### Using Progress Bars
+
+```go
+progress := r.Progress(renderer.ProgressSpec{
+    Label: "Installing dependencies",
+    Total: 100,
+})
+
+for i := 0; i <= 100; i++ {
+    progress.Increment(1)
+    time.Sleep(50 * time.Millisecond)
+}
+
+progress.Done()
+```
+
+### JSON Output
+
+All commands automatically support `--json`:
+
+```bash
+$ tracks version --json
+{
+  "title": "Tracks v0.1.0",
+  "sections": [
+    {
+      "title": "",
+      "body": "Commit: abc123\nBuilt: 2025-10-24"
+    }
+  ]
+}
+```
+
+## Mode Detection
+
+### Environment Variables
+
+- **NO_COLOR** - Disables colors (standard env var)
+- **TRACKS_JSON** - Forces JSON mode
+- **TRACKS_NO_COLOR** - Same as NO_COLOR
+- **TRACKS_INTERACTIVE** - Forces interactive TUI mode
+- **TRACKS_LOG_LEVEL** - Sets verbosity (debug, info, warn, error, off)
+- **CI** - Detected automatically, forces console mode
+
+### Flags
+
+- `--json` - Output JSON (highest priority)
+- `--no-color` - Disable colors
+- `--interactive` - Force interactive TUI mode
+- `-v, --verbose` - Enable verbose output
+- `-q, --quiet` - Suppress non-error output
+
+**Mutual Exclusivity:** `--verbose` and `--quiet` cannot be used together.
+
+## Adding New Commands
+
+1. **Create command function** in `root.go` or separate file:
+
+```go
+func newFeatureCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:   "feature [args]",
+        Short: "Does something",
+        Long:  "Detailed description...",
+        Args:  cobra.ExactArgs(1),
+        Run: func(cmd *cobra.Command, args []string) {
+            r := NewRendererFromCommand(cmd)
+
+            // Your logic here
+
+            flushRenderer(cmd, r)
+        },
+    }
+}
+```
+
+1. **Register in NewRootCmd:**
+
+```go
+rootCmd.AddCommand(newFeatureCmd())
+```
+
+1. **Add tests** in `root_test.go` and `test/integration/cli_test.go`
+
+## Extending the Renderer
+
+### Adding a New Renderer Implementation
+
+1. **Create new file** (e.g., `renderer/markdown.go`)
+2. **Implement Renderer interface:**
+
+```go
+type MarkdownRenderer struct {
+    w io.Writer
+}
+
+func NewMarkdownRenderer(w io.Writer) *MarkdownRenderer {
+    return &MarkdownRenderer{w: w}
+}
+
+func (r *MarkdownRenderer) Title(s string) {
+    fmt.Fprintf(r.w, "# %s\n\n", s)
+}
+
+func (r *MarkdownRenderer) Section(sec Section) {
+    if sec.Title != "" {
+        fmt.Fprintf(r.w, "## %s\n\n", sec.Title)
+    }
+    fmt.Fprintf(r.w, "%s\n\n", sec.Body)
+}
+
+// ... implement other methods
+```
+
+1. **Update NewRendererFromCommand** to support new mode
+2. **Add tests** in `renderer/markdown_test.go`
+
+### Adding a New UIMode
+
+1. **Add constant** to `ui/mode.go`:
+
+```go
+const (
+    ModeAuto UIMode = iota
+    ModeConsole
+    ModeJSON
+    ModeTUI
+    ModeMarkdown  // New mode
+)
+```
+
+1. **Update String() method**
+2. **Update DetectMode()** logic
+3. **Add flag or env var** support in `root.go`
+
+## Testing Strategies
+
+### Unit Tests
+
+Test individual components in isolation:
+
+```go
+func TestMyCommand(t *testing.T) {
+    var buf bytes.Buffer
+
+    cmd := myCmd()
+    cmd.SetOut(&buf)
+    cmd.SetArgs([]string{"arg1"})
+
+    if err := cmd.Execute(); err != nil {
+        t.Fatalf("command failed: %v", err)
+    }
+
+    output := buf.String()
+    if !strings.Contains(output, "expected") {
+        t.Errorf("unexpected output: %s", output)
+    }
+}
+```
+
+### Integration Tests
+
+Test the compiled binary:
+
+```go
+//go:build integration
+
+func TestCLIVersion(t *testing.T) {
+    stdout, _ := RunCLIExpectSuccess(t, "version")
+    AssertContains(t, stdout, "Tracks")
+}
+```
+
+Run with: `make test-integration`
+
+### Renderer Tests
+
+Use table-driven tests for different renderers:
+
+```go
+func TestRenderersImplementInterface(t *testing.T) {
+    var buf bytes.Buffer
+
+    renderers := map[string]renderer.Renderer{
+        "console": renderer.NewConsoleRenderer(&buf),
+        "json":    renderer.NewJSONRenderer(&buf),
+    }
+
+    for name, r := range renderers {
+        t.Run(name, func(t *testing.T) {
+            r.Title("Test")
+            // assertions...
+        })
+    }
+}
+```
+
+## Development Workflow
+
+### Building
+
+```bash
+# Build CLI binary
+make build
+
+# Binary outputs to: ./bin/tracks
+```
+
+### Testing
+
+```bash
+# Run unit tests
+make test
+
+# Run integration tests (requires build)
+make test-integration
+
+# Run all tests
+make test-all
+
+# Run with coverage
+make test-coverage
+```
+
+### Linting
+
+```bash
+# Run all linters
+make lint
+
+# Run specific linters
+make lint-go
+make lint-md
+```
+
+### Running Locally
+
+```bash
+# Run without installing
+./bin/tracks version
+
+# Install to GOPATH
+go install ./cmd/tracks
+
+# Run installed version
+tracks version
+```
+
+### Debugging
+
+```bash
+# Enable verbose output
+tracks -v version
+
+# Output JSON for inspection
+tracks --json version | jq
+
+# Check environment variable detection
+TRACKS_LOG_LEVEL=debug tracks version
+```
+
+## Common Pitfalls
+
+### 1. Forgetting to Flush
+
+**Problem:** Output doesn't appear
+
+```go
+// BAD
+r.Title("Hello")
+// Forgot to flush!
+```
+
+**Solution:** Always call `flushRenderer(cmd, r)` or `r.Flush()`
+
+### 2. Not Using Helper Functions
+
+**Problem:** Repeating renderer initialization
+
+```go
+// BAD - duplicated in every command
+cfg := GetConfig(cmd)
+uiMode := ui.DetectMode(...)
+var r renderer.Renderer
+if uiMode == ui.ModeJSON {
+    r = renderer.NewJSONRenderer(...)
+}
+```
+
+**Solution:** Use the helper
+
+```go
+// GOOD
+r := NewRendererFromCommand(cmd)
+```
+
+### 3. Wrong Zero Values in Structs
+
+**Problem:** Explicitly setting zero values
+
+```go
+// BAD - Title: "" is unnecessary
+r.Section(renderer.Section{
+    Title: "",
+    Body:  "content",
+})
+```
+
+**Solution:** Omit zero-value fields
+
+```go
+// GOOD
+r.Section(renderer.Section{
+    Body: "content",
+})
+```
+
+### 4. Calling Flush Multiple Times
+
+**Problem:** Calling Flush in a loop
+
+```go
+// BAD
+for _, item := range items {
+    r.Section(...)
+    r.Flush()  // Don't flush inside loop!
+}
+```
+
+**Solution:** Accumulate, then flush once
+
+```go
+// GOOD
+for _, item := range items {
+    r.Section(...)
+}
+r.Flush()  // Flush once at end
+```
+
+### 5. Forgetting Integration Tests
+
+**Problem:** Only unit testing commands
+
+**Solution:** Add integration tests that execute the binary:
+
+```go
+func TestCLIMyCommand(t *testing.T) {
+    stdout, _ := RunCLIExpectSuccess(t, "mycommand", "arg")
+    AssertContains(t, stdout, "expected output")
+}
+```
+
+## Theme Customization
+
+### Using Theme in Custom Code
+
+```go
+import "github.com/anomalousventures/tracks/internal/cli/ui"
+
+// Render styled output
+fmt.Println(ui.Theme.Title.Render("My Title"))
+fmt.Println(ui.Theme.Success.Render("✓ Success"))
+fmt.Println(ui.Theme.Error.Render("✗ Error"))
+```
+
+### Checking NO_COLOR
+
+Theme automatically respects `NO_COLOR`, but you can check manually:
+
+```go
+import "github.com/charmbracelet/lipgloss"
+
+if lipgloss.HasDarkBackground() {
+    // Adjust colors for dark terminals
+}
+```
+
+## Helper Functions Reference
+
+### NewRendererFromCommand
+
+Creates appropriate renderer based on flags/env vars.
+
+```go
+func NewRendererFromCommand(cmd *cobra.Command) renderer.Renderer
+```
+
+**Returns:** ConsoleRenderer or JSONRenderer based on configuration.
+
+### flushRenderer
+
+Flushes renderer and handles errors.
+
+```go
+func flushRenderer(cmd *cobra.Command, r renderer.Renderer)
+```
+
+**Effect:** Writes output, prints errors to stderr, exits on failure.
+
+### GetConfig
+
+Extracts CLI configuration from command context.
+
+```go
+func GetConfig(cmd *cobra.Command) Config
+```
+
+**Returns:** Config struct with all flag and env var values.
+
+### GetViper
+
+Retrieves Viper instance from command context.
+
+```go
+func GetViper(cmd *cobra.Command) *viper.Viper
+```
+
+**Returns:** Viper instance or new instance if none in context.
+
+## Related Documentation
+
+- [Renderer Deep Dive](./renderer/README.md) - Detailed Renderer pattern docs
+- [Project README](../../README.md) - Overview and vision
+- [Contributing Guide](../../CONTRIBUTING.md) - Development guidelines
+- [Release Process](../../docs/RELEASING.md) - Version management
+
+## Future: Interactive TUI (Phase 4)
+
+The TUI mode will use Bubble Tea for interactive experiences:
+
+- File browser for code generation
+- Form-based configuration
+- Real-time progress updates
+- Keyboard navigation
+
+The Renderer pattern is designed to make this easy - just add `TUIRenderer` and update `DetectMode()`.

--- a/internal/cli/renderer/README.md
+++ b/internal/cli/renderer/README.md
@@ -1,0 +1,654 @@
+# Renderer Pattern Deep Dive
+
+The Renderer pattern is the core abstraction for CLI output in Tracks. It separates **what** to display from **how** to display it.
+
+## Design Philosophy
+
+### Separation of Concerns
+
+```text
+Command Logic          Renderer Implementation
+┌──────────────┐      ┌────────────────────┐
+│              │      │                    │
+│ • Validation │──────▶│ • Format output   │
+│ • Business   │ data │ • Apply styles    │
+│ • Data fetch │──────▶│ • Handle errors   │
+│              │      │                    │
+└──────────────┘      └────────────────────┘
+```
+
+Commands produce **data** (titles, sections, tables). Renderers format that data for different contexts (terminal, JSON, TUI).
+
+### Benefits
+
+1. **Testability** - Mock renderers for unit tests
+2. **Flexibility** - Add new output formats without changing commands
+3. **Consistency** - All commands use the same output primitives
+4. **Maintainability** - Output logic isolated from business logic
+
+## Interface
+
+```go
+type Renderer interface {
+    // Title displays a prominent heading
+    Title(string)
+
+    // Section displays titled content blocks
+    Section(Section)
+
+    // Table displays structured data in rows/columns
+    Table(Table)
+
+    // Progress creates a tracker for long-running operations
+    Progress(ProgressSpec) Progress
+
+    // Flush writes all accumulated output
+    Flush() error
+}
+```
+
+### Supporting Types
+
+```go
+// Section represents a content block with optional title
+type Section struct {
+    Title string  // Optional heading
+    Body  string  // Main content
+}
+
+// Table represents structured tabular data
+type Table struct {
+    Headers []string    // Column headers
+    Rows    [][]string  // Data rows
+}
+
+// ProgressSpec configures a progress tracker
+type ProgressSpec struct {
+    Label string   // Display label
+    Total int64    // Total items
+}
+
+// Progress tracks incremental updates
+type Progress interface {
+    Increment(int64)  // Update progress
+    Done()            // Mark complete
+}
+```
+
+## Implementations
+
+### ConsoleRenderer
+
+Human-readable terminal output using Lip Gloss for styling.
+
+**Features:**
+
+- Colored output (respects NO_COLOR)
+- Themed styles (Title, Success, Error, Warning, Muted)
+- Table alignment with lipgloss.Table
+- Progress bars using Bubbles progress component
+- Direct writes (no buffering)
+
+**Usage:**
+
+```go
+r := renderer.NewConsoleRenderer(os.Stdout)
+
+r.Title("Installation Complete")
+r.Section(renderer.Section{
+    Body: "Successfully installed 15 packages",
+})
+r.Table(renderer.Table{
+    Headers: []string{"Package", "Version"},
+    Rows: [][]string{
+        {"cobra", "1.10.1"},
+        {"viper", "1.20.1"},
+    },
+})
+
+progress := r.Progress(renderer.ProgressSpec{
+    Label: "Downloading",
+    Total: 100,
+})
+for i := 0; i <= 100; i++ {
+    progress.Increment(1)
+    time.Sleep(10 * time.Millisecond)
+}
+progress.Done()
+
+if err := r.Flush(); err != nil {
+    log.Fatal(err)
+}
+```
+
+**Output:**
+
+```text
+Installation Complete
+
+Successfully installed 15 packages
+
+Package         Version
+──────────────────────
+cobra           1.10.1
+viper           1.20.1
+
+Downloading [████████████████████] 100%
+```
+
+### JSONRenderer
+
+Machine-readable JSON for scripting and automation.
+
+**Features:**
+
+- Structured JSON output
+- Accumulates all data before writing
+- Pretty-printed with 2-space indentation
+- No-op progress (JSON not suitable for incremental updates)
+
+**Usage:**
+
+```go
+r := renderer.NewJSONRenderer(os.Stdout)
+
+r.Title("Installation Complete")
+r.Section(renderer.Section{
+    Body: "Successfully installed 15 packages",
+})
+r.Table(renderer.Table{
+    Headers: []string{"Package", "Version"},
+    Rows: [][]string{
+        {"cobra", "1.10.1"},
+        {"viper", "1.20.1"},
+    },
+})
+
+if err := r.Flush(); err != nil {
+    log.Fatal(err)
+}
+```
+
+**Output:**
+
+```json
+{
+  "title": "Installation Complete",
+  "sections": [
+    {
+      "title": "",
+      "body": "Successfully installed 15 packages"
+    }
+  ],
+  "tables": [
+    {
+      "headers": ["Package", "Version"],
+      "rows": [
+        ["cobra", "1.10.1"],
+        ["viper", "1.20.1"]
+      ]
+    }
+  ]
+}
+```
+
+### TUIRenderer (Phase 4)
+
+Interactive Bubble Tea interface for immersive experiences.
+
+**Planned Features:**
+
+- Full-screen TUI application
+- Keyboard navigation
+- Real-time updates
+- Form inputs
+- File browsers
+- Confirmation dialogs
+
+## Implementation Guide
+
+### Creating a New Renderer
+
+Let's create a Markdown renderer as an example.
+
+#### 1. Create File
+
+```go
+// internal/cli/renderer/markdown.go
+package renderer
+
+import (
+    "fmt"
+    "io"
+    "strings"
+)
+
+type MarkdownRenderer struct {
+    w io.Writer
+}
+
+func NewMarkdownRenderer(w io.Writer) *MarkdownRenderer {
+    return &MarkdownRenderer{w: w}
+}
+```
+
+#### 2. Implement Title
+
+```go
+func (r *MarkdownRenderer) Title(s string) {
+    fmt.Fprintf(r.w, "# %s\n\n", s)
+}
+```
+
+#### 3. Implement Section
+
+```go
+func (r *MarkdownRenderer) Section(sec Section) {
+    if sec.Title != "" {
+        fmt.Fprintf(r.w, "## %s\n\n", sec.Title)
+    }
+    if sec.Body != "" {
+        fmt.Fprintf(r.w, "%s\n\n", sec.Body)
+    }
+}
+```
+
+#### 4. Implement Table
+
+```go
+func (r *MarkdownRenderer) Table(t Table) {
+    if len(t.Headers) == 0 {
+        return
+    }
+
+    // Headers
+    fmt.Fprintf(r.w, "| %s |\n", strings.Join(t.Headers, " | "))
+
+    // Separator
+    sep := make([]string, len(t.Headers))
+    for i := range sep {
+        sep[i] = "---"
+    }
+    fmt.Fprintf(r.w, "| %s |\n", strings.Join(sep, " | "))
+
+    // Rows
+    for _, row := range t.Rows {
+        cells := make([]string, len(t.Headers))
+        for i := range t.Headers {
+            if i < len(row) {
+                cells[i] = row[i]
+            }
+        }
+        fmt.Fprintf(r.w, "| %s |\n", strings.Join(cells, " | "))
+    }
+    fmt.Fprintln(r.w)
+}
+```
+
+#### 5. Implement Progress
+
+```go
+type markdownProgress struct{}
+
+func (p *markdownProgress) Increment(n int64) {}
+func (p *markdownProgress) Done()             {}
+
+func (r *MarkdownRenderer) Progress(spec ProgressSpec) Progress {
+    // Markdown doesn't support progress bars
+    return &markdownProgress{}
+}
+```
+
+#### 6. Implement Flush
+
+```go
+func (r *MarkdownRenderer) Flush() error {
+    // Markdown writes immediately, nothing to flush
+    return nil
+}
+```
+
+#### 7. Add Tests
+
+```go
+// internal/cli/renderer/markdown_test.go
+package renderer_test
+
+import (
+    "bytes"
+    "strings"
+    "testing"
+
+    "github.com/anomalousventures/tracks/internal/cli/renderer"
+)
+
+func TestMarkdownRenderer(t *testing.T) {
+    var buf bytes.Buffer
+    r := renderer.NewMarkdownRenderer(&buf)
+
+    r.Title("Test Title")
+    r.Section(renderer.Section{
+        Title: "Section",
+        Body:  "Content",
+    })
+    r.Table(renderer.Table{
+        Headers: []string{"A", "B"},
+        Rows:    [][]string{{"1", "2"}},
+    })
+
+    if err := r.Flush(); err != nil {
+        t.Fatalf("Flush failed: %v", err)
+    }
+
+    output := buf.String()
+
+    if !strings.Contains(output, "# Test Title") {
+        t.Error("Missing title")
+    }
+    if !strings.Contains(output, "## Section") {
+        t.Error("Missing section title")
+    }
+    if !strings.Contains(output, "| A | B |") {
+        t.Error("Missing table")
+    }
+}
+```
+
+#### 8. Integrate with CLI
+
+Update `internal/cli/root.go`:
+
+```go
+// Add mode constant in ui/mode.go
+const (
+    ModeAuto UIMode = iota
+    ModeConsole
+    ModeJSON
+    ModeTUI
+    ModeMarkdown  // New
+)
+
+// Update DetectMode() in ui/mode.go
+func DetectMode(cfg UIConfig) UIMode {
+    // ... existing logic ...
+    if cfg.Markdown {  // Add Markdown flag
+        return ModeMarkdown
+    }
+    // ... rest of detection ...
+}
+
+// Update NewRendererFromCommand() in root.go
+func NewRendererFromCommand(cmd *cobra.Command) renderer.Renderer {
+    cfg := GetConfig(cmd)
+    uiMode := ui.DetectMode(...)
+
+    switch uiMode {
+    case ui.ModeJSON:
+        return renderer.NewJSONRenderer(cmd.OutOrStdout())
+    case ui.ModeMarkdown:
+        return renderer.NewMarkdownRenderer(cmd.OutOrStdout())
+    default:
+        return renderer.NewConsoleRenderer(cmd.OutOrStdout())
+    }
+}
+
+// Add flag in NewRootCmd()
+rootCmd.PersistentFlags().Bool("markdown", false, "Output in Markdown format")
+```
+
+## Design Patterns
+
+### Accumulate-Then-Flush
+
+Some renderers need to see all data before rendering (e.g., JSON needs complete structure).
+
+```go
+type AccumulatingRenderer struct {
+    data  OutputData
+    w     io.Writer
+}
+
+func (r *AccumulatingRenderer) Title(s string) {
+    r.data.Title = s  // Store, don't write yet
+}
+
+func (r *AccumulatingRenderer) Flush() error {
+    // Now write everything as complete structure
+    return json.NewEncoder(r.w).Encode(r.data)
+}
+```
+
+### Immediate Write
+
+Other renderers write immediately (e.g., Console for interactive feedback).
+
+```go
+type ImmediateRenderer struct {
+    w io.Writer
+}
+
+func (r *ImmediateRenderer) Title(s string) {
+    fmt.Fprintln(r.w, s)  // Write immediately
+}
+
+func (r *ImmediateRenderer) Flush() error {
+    return nil  // Nothing buffered
+}
+```
+
+### No-Op Progress
+
+If a renderer can't support progress bars, provide a no-op implementation:
+
+```go
+type noOpProgress struct{}
+
+func (p *noOpProgress) Increment(n int64) {}
+func (p *noOpProgress) Done()             {}
+
+func (r *MyRenderer) Progress(spec ProgressSpec) Progress {
+    return &noOpProgress{}
+}
+```
+
+## Testing Strategies
+
+### Test All Implementations
+
+Use table-driven tests to ensure all renderers work:
+
+```go
+func TestRendererImplementations(t *testing.T) {
+    tests := []struct {
+        name string
+        r    renderer.Renderer
+    }{
+        {"console", renderer.NewConsoleRenderer(&bytes.Buffer{})},
+        {"json", renderer.NewJSONRenderer(&bytes.Buffer{})},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            tt.r.Title("Test")
+            if err := tt.r.Flush(); err != nil {
+                t.Errorf("Flush failed: %v", err)
+            }
+        })
+    }
+}
+```
+
+### Mock Renderer for Command Tests
+
+```go
+type MockRenderer struct {
+    Titles   []string
+    Sections []renderer.Section
+    Flushed  bool
+}
+
+func (m *MockRenderer) Title(s string) {
+    m.Titles = append(m.Titles, s)
+}
+
+func (m *MockRenderer) Section(s renderer.Section) {
+    m.Sections = append(m.Sections, s)
+}
+
+func (m *MockRenderer) Flush() error {
+    m.Flushed = true
+    return nil
+}
+
+// Use in tests
+func TestMyCommand(t *testing.T) {
+    mock := &MockRenderer{}
+    myCommandLogic(mock)
+
+    if len(mock.Titles) != 1 {
+        t.Error("Expected 1 title")
+    }
+    if !mock.Flushed {
+        t.Error("Renderer not flushed")
+    }
+}
+```
+
+### Integration Tests
+
+Test complete flow with real renderers:
+
+```go
+func TestConsoleOutput(t *testing.T) {
+    var buf bytes.Buffer
+    r := renderer.NewConsoleRenderer(&buf)
+
+    r.Title("Test")
+    r.Section(renderer.Section{Body: "Content"})
+    r.Flush()
+
+    output := buf.String()
+    if !strings.Contains(output, "Test") {
+        t.Error("Title missing from output")
+    }
+}
+```
+
+## Common Pitfalls
+
+### 1. Forgetting Flush
+
+```go
+// BAD - no output appears
+r.Title("Hello")
+// Forgot r.Flush()!
+```
+
+### 2. Flushing Too Early
+
+```go
+// BAD - JSON would be incomplete
+r.Title("Test")
+r.Flush()       // Too early!
+r.Section(...)  // Won't be included
+```
+
+### 3. Assuming IO Never Fails
+
+```go
+// BAD - ignoring error
+r.Flush()
+
+// GOOD - checking error
+if err := r.Flush(); err != nil {
+    return fmt.Errorf("output failed: %w", err)
+}
+```
+
+### 4. Testing Output Format
+
+```go
+// BAD - brittle test
+if output != "exact string" { ... }
+
+// GOOD - semantic test
+if !strings.Contains(output, "key content") { ... }
+```
+
+### 5. Not Implementing All Methods
+
+```go
+// BAD - panic at runtime
+func (r *MyRenderer) Progress(...) Progress {
+    panic("not implemented")
+}
+
+// GOOD - no-op implementation
+func (r *MyRenderer) Progress(...) Progress {
+    return &noOpProgress{}
+}
+```
+
+## Performance Considerations
+
+### Buffering
+
+For network/file writes, use buffering:
+
+```go
+func NewFileRenderer(filename string) (*FileRenderer, error) {
+    f, err := os.Create(filename)
+    if err != nil {
+        return nil, err
+    }
+    return &FileRenderer{
+        w: bufio.NewWriter(f),  // Buffered!
+        f: f,
+    }, nil
+}
+
+func (r *FileRenderer) Flush() error {
+    // Flush buffer first
+    if err := r.w.(*bufio.Writer).Flush(); err != nil {
+        return err
+    }
+    // Then sync file
+    return r.f.Sync()
+}
+```
+
+### Large Tables
+
+Stream large tables row-by-row instead of buffering:
+
+```go
+func (r *StreamRenderer) Table(t Table) {
+    r.writeHeaders(t.Headers)
+    for _, row := range t.Rows {
+        r.writeRow(row)  // Write immediately
+    }
+}
+```
+
+## Future Enhancements
+
+### Planned Features (Phase 4)
+
+- **TUIRenderer** - Full-screen Bubble Tea interface
+- **HTMLRenderer** - For generated documentation
+- **MarkdownRenderer** - For README generation
+- **Streaming renderers** - For long-running commands
+
+### Extension Points
+
+The Renderer interface may grow to support:
+
+- Prompts/Input (`Prompt(question string) (answer string)`)
+- Confirmations (`Confirm(message string) bool`)
+- Multi-select (`Select(options []string) []int`)
+
+## Related Documentation
+
+- [CLI Architecture](../README.md) - Overall CLI design
+- [Theme System](../ui/theme.go) - Lip Gloss styles
+- [Mode Detection](../ui/mode.go) - Output mode logic

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -188,6 +188,12 @@ func NewRendererFromCommand(cmd *cobra.Command) renderer.Renderer {
 	if uiMode == ui.ModeJSON {
 		return renderer.NewJSONRenderer(cmd.OutOrStdout())
 	}
+
+	// Set NO_COLOR env var if --no-color flag is set, so Lip Gloss respects it
+	if cfg.NoColor {
+		os.Setenv("NO_COLOR", "1")
+	}
+
 	return renderer.NewConsoleRenderer(cmd.OutOrStdout())
 }
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -152,8 +152,8 @@ const config = {
         // The application ID provided by Algolia
         appId: 'KHXZYX55H6',
 
-        // Public API key: it is safe to commit it
-        apiKey: '',
+        // Public API key: it is safe to commit it (placeholder until DocSearch is configured)
+        apiKey: 'placeholder',
 
         indexName: 'tracks',
 


### PR DESCRIPTION
## What

Completes Epic 1: CLI Infrastructure by fixing the --no-color flag bug and adding internal developer documentation.

## Why

- --no-color flag wasn't working because it didn't set NO_COLOR env var for Lip Gloss
- Internal docs needed for developers working on CLI codebase
- Epic 1 completion required for v0.1.0 release

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)
- [x] Manual verification of --no-color flag fix

## Notes

All 23 tasks of Epic 1 are complete. User-facing docs (CLI pages, blog post) are stashed and will be published post-release.

Next: Tag v0.1.0, then Epic 2 (Template Engine).

Closes #24