### PR TITLE
fix(release): update GoReleaser for v2 and add Linux packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -141,19 +141,14 @@ docker_manifests:
       - 'ghcr.io/anomalousventures/tracks:latest-amd64'
       - 'ghcr.io/anomalousventures/tracks:latest-arm64'
 
-brews:
+homebrew_casks:
   - repository:
       owner: anomalousventures
       name: homebrew-tap
       token: "{{ .Env.GITHUB_TOKEN }}"
-    folder: Formula
     homepage: https://tracks.anomalousventures.com
-    description: A Rails-like web framework for Go
+    description: A batteries included toolkit for hypermedia servers
     license: MIT
-    test: |
-      system "#{bin}/tracks version"
-    install: |
-      bin.install "tracks"
 
 scoops:
   - repository:
@@ -161,8 +156,27 @@ scoops:
       name: scoop-bucket
       token: "{{ .Env.GITHUB_TOKEN }}"
     homepage: https://tracks.anomalousventures.com
-    description: A Rails-like web framework for Go
+    description: A batteries included toolkit for hypermedia servers
     license: MIT
+
+nfpms:
+  - id: packages
+    package_name: tracks
+    vendor: Anomalous Ventures
+    homepage: https://tracks.anomalousventures.com
+    maintainer: Anomalous Ventures <info@anomalous.ventures>
+    description: A batteries included toolkit for hypermedia servers
+    license: MIT
+    formats:
+      - deb
+      - rpm
+      - apk
+    bindir: /usr/bin
+    contents:
+      - src: ./LICENSE
+        dst: /usr/share/doc/tracks/LICENSE
+      - src: ./README.md
+        dst: /usr/share/doc/tracks/README.md
 
 announce:
   skip: '{{gt .Patch 0}}'  # Skip patch releases
@@ -171,6 +185,7 @@ release:
   github:
     owner: anomalousventures
     name: tracks
+  draft: true
   prerelease: auto
   name_template: "Tracks {{.Version}}"
   header: |


### PR DESCRIPTION
## What

Updates GoReleaser configuration to v2 syntax and adds Linux package generation for v0.1.0 release.

## Why

- Current `brews` config uses deprecated v1 syntax that fails validation in GoReleaser v2.10+
- Need Linux packages (.deb, .rpm, .apk) for broader distribution
- Draft mode allows manual review before publishing
- Homebrew/Scoop repos now exist and need proper config

## Testing

- [x] Tests pass locally (`make test`)
- [x] Linting passes (`make lint`)
- [x] GoReleaser config validates (`go tool goreleaser check`)

## Notes

**Changes:**
- Migrated `brews` → `homebrew_casks` (removed deprecated `folder` field)
- Added `nfpms` section for .deb/.rpm/.apk generation
- Enabled `draft: true` for manual release review
- Updated descriptions to match README tagline
- Updated maintainer email to info@anomalous.ventures

**Release workflow:**
1. Tag push → draft release created
2. Manual review/edit
3. Publish → Homebrew/Scoop automatically updated