### PR TITLE
fix(release): add QEMU and Buildx for multi-arch Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,14 @@ jobs:
       - name: Run tests
         run: go test -v ./...
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
## What

Adds Docker QEMU and Buildx setup steps to the release workflow to enable multi-architecture Docker image builds (AMD64 + ARM64).

## Why

The v0.1.0 release workflow fails when building ARM64 Docker images on AMD64 GitHub Actions runners with error:
```
#6 [2/4] RUN apk --no-cache add ca-certificates
#6 0.138 exec /bin/sh: exec format error
```

Without QEMU emulation, the runner cannot execute ARM64 binaries during the Docker build process.

## Testing

- [x] Verified latest action versions (v3.6.0 for QEMU/login, v3.11.1 for Buildx)
- [ ] Will re-push v0.1.0 tag after merge to test full release workflow

## Notes

This is the third blocker for v0.1.0 release (first: missing CHANGELOG.md, second: this Docker build failure). Once merged, will delete and re-push v0.1.0 tag to trigger the release workflow.