### PR TITLE
fix(release): use TRACKS_RELEASER_TOKEN for Homebrew/Scoop publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRACKS_RELEASER_TOKEN: ${{ secrets.TRACKS_RELEASER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -145,7 +145,7 @@ homebrew_casks:
   - repository:
       owner: anomalousventures
       name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.TRACKS_RELEASER_TOKEN }}"
     homepage: https://tracks.anomalousventures.com
     description: A batteries included toolkit for hypermedia servers
     license: MIT
@@ -154,7 +154,7 @@ scoops:
   - repository:
       owner: anomalousventures
       name: scoop-bucket
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.TRACKS_RELEASER_TOKEN }}"
     homepage: https://tracks.anomalousventures.com
     description: A batteries included toolkit for hypermedia servers
     license: MIT


### PR DESCRIPTION
## What

Configures GoReleaser to use `TRACKS_RELEASER_TOKEN` instead of `GITHUB_TOKEN` for publishing to Homebrew tap and Scoop bucket repositories.

## Why

The v0.1.0 release failed with 403 errors when trying to update homebrew-tap and scoop-bucket repos:
```
403 Resource not accessible by integration
```

GitHub Actions default `GITHUB_TOKEN` only has write permissions for the repository running the workflow. GoReleaser documentation explicitly states: "For GitHub Actions, you cannot use the default action token. You must use a separate token with content write privileges for the tap repository."

## Testing

- [x] Updated `.goreleaser.yml` to use `{{ .Env.TRACKS_RELEASER_TOKEN }}`
- [x] Updated `.github/workflows/release.yml` to pass `TRACKS_RELEASER_TOKEN` env var
- [x] `TRACKS_RELEASER_TOKEN` secret added to repository with repo scope
- [ ] Will re-attempt v0.1.0 release after merge

## Notes

After this merges, will:
1. Delete current draft release
2. Delete v0.1.0 tag
3. Re-create and push v0.1.0 tag to trigger full release with working Homebrew/Scoop publishing