### PR TITLE
fix(release): remove duplicate changelog from release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -193,10 +193,6 @@ release:
 
     Welcome to this new release of Tracks!
 
-    ### Highlights
-
-    {{ .ReleaseNotes }}
-
   footer: |
     ## Install or Upgrade
 


### PR DESCRIPTION
## What

Removes `{{ .ReleaseNotes }}` from the release header template to prevent changelog duplication.

## Why

The current v0.1.0 draft release shows the changelog twice:
1. First from `{{ .ReleaseNotes }}` in the header template
2. Second from GoReleaser's automatic changelog generation

GoReleaser automatically appends the generated changelog after the header template, so we don't need to include it in the header.

## Testing

- [x] Removed `{{ .ReleaseNotes }}` and empty "Highlights" section
- [ ] Will re-create v0.1.0 tag after merge to generate clean release notes

## Notes

This is the 5th attempt at the v0.1.0 release. After this merges:
1. Delete current draft release
2. Delete v0.1.0 tag
3. Re-push v0.1.0 tag
4. Verify clean changelog
5. Publish release