### PR TITLE
feat(template): define core interfaces, types, and errors

### DIFF
--- a/internal/generator/template/data.go
+++ b/internal/generator/template/data.go
@@ -1,0 +1,25 @@
+package template
+
+// TemplateData contains all variables available to templates during rendering.
+// This struct defines the complete schema of data that can be used in template files.
+type TemplateData struct {
+	// ModuleName is the full Go module path for the generated project.
+	// Example: "github.com/user/myapp"
+	ModuleName string
+
+	// ProjectName is the short name of the project, typically the last segment of the module path.
+	// Example: "myapp"
+	ProjectName string
+
+	// DBDriver specifies the database driver to use in the generated project.
+	// Valid values: "go-libsql", "sqlite3", "postgres"
+	DBDriver string
+
+	// GoVersion specifies the Go version to use in the generated project's go.mod file.
+	// Example: "1.25"
+	GoVersion string
+
+	// Year is the current year, used for copyright notices in generated files.
+	// Example: 2025
+	Year int
+}

--- a/internal/generator/template/data_test.go
+++ b/internal/generator/template/data_test.go
@@ -1,0 +1,87 @@
+package template
+
+import "testing"
+
+// TestTemplateDataStruct tests that TemplateData can be initialized and accessed
+func TestTemplateDataStruct(t *testing.T) {
+	data := TemplateData{
+		ModuleName:  "github.com/user/myapp",
+		ProjectName: "myapp",
+		DBDriver:    "sqlite3",
+		GoVersion:   "1.25",
+		Year:        2025,
+	}
+
+	if data.ModuleName != "github.com/user/myapp" {
+		t.Errorf("ModuleName = %q, want %q", data.ModuleName, "github.com/user/myapp")
+	}
+
+	if data.ProjectName != "myapp" {
+		t.Errorf("ProjectName = %q, want %q", data.ProjectName, "myapp")
+	}
+
+	if data.DBDriver != "sqlite3" {
+		t.Errorf("DBDriver = %q, want %q", data.DBDriver, "sqlite3")
+	}
+
+	if data.GoVersion != "1.25" {
+		t.Errorf("GoVersion = %q, want %q", data.GoVersion, "1.25")
+	}
+
+	if data.Year != 2025 {
+		t.Errorf("Year = %d, want %d", data.Year, 2025)
+	}
+}
+
+// TestTemplateDataZeroValue tests the zero value of TemplateData
+func TestTemplateDataZeroValue(t *testing.T) {
+	var data TemplateData
+
+	if data.ModuleName != "" {
+		t.Errorf("zero value ModuleName = %q, want empty string", data.ModuleName)
+	}
+
+	if data.ProjectName != "" {
+		t.Errorf("zero value ProjectName = %q, want empty string", data.ProjectName)
+	}
+
+	if data.DBDriver != "" {
+		t.Errorf("zero value DBDriver = %q, want empty string", data.DBDriver)
+	}
+
+	if data.GoVersion != "" {
+		t.Errorf("zero value GoVersion = %q, want empty string", data.GoVersion)
+	}
+
+	if data.Year != 0 {
+		t.Errorf("zero value Year = %d, want 0", data.Year)
+	}
+}
+
+// TestTemplateDataPartialInitialization tests partial struct initialization
+func TestTemplateDataPartialInitialization(t *testing.T) {
+	data := TemplateData{
+		ModuleName: "github.com/user/app",
+		Year:       2025,
+	}
+
+	if data.ModuleName != "github.com/user/app" {
+		t.Errorf("ModuleName = %q, want %q", data.ModuleName, "github.com/user/app")
+	}
+
+	if data.Year != 2025 {
+		t.Errorf("Year = %d, want %d", data.Year, 2025)
+	}
+
+	if data.ProjectName != "" {
+		t.Errorf("unset ProjectName = %q, want empty string", data.ProjectName)
+	}
+
+	if data.DBDriver != "" {
+		t.Errorf("unset DBDriver = %q, want empty string", data.DBDriver)
+	}
+
+	if data.GoVersion != "" {
+		t.Errorf("unset GoVersion = %q, want empty string", data.GoVersion)
+	}
+}

--- a/internal/generator/template/errors.go
+++ b/internal/generator/template/errors.go
@@ -1,0 +1,46 @@
+package template
+
+import "fmt"
+
+// TemplateError represents an error that occurred during template rendering.
+// It wraps the underlying error with the template name for better context.
+type TemplateError struct {
+	// Template is the name of the template that caused the error
+	Template string
+
+	// Err is the underlying error
+	Err error
+}
+
+// Error implements the error interface for TemplateError.
+// It returns a formatted error message that includes the template name and underlying error.
+func (e *TemplateError) Error() string {
+	return fmt.Sprintf("template %s: %v", e.Template, e.Err)
+}
+
+// Unwrap returns the underlying error for error chain unwrapping.
+func (e *TemplateError) Unwrap() error {
+	return e.Err
+}
+
+// ValidationError represents an error that occurred during template validation.
+// It includes the template name, the problematic field, and a descriptive message.
+type ValidationError struct {
+	// Template is the name of the template being validated
+	Template string
+
+	// Field is the name of the field that failed validation (empty if not field-specific)
+	Field string
+
+	// Message describes the validation failure
+	Message string
+}
+
+// Error implements the error interface for ValidationError.
+// It returns a formatted error message with template name, field, and message.
+func (e *ValidationError) Error() string {
+	if e.Field != "" {
+		return fmt.Sprintf("template %s: field %s: %s", e.Template, e.Field, e.Message)
+	}
+	return fmt.Sprintf("template %s: %s", e.Template, e.Message)
+}

--- a/internal/generator/template/errors_test.go
+++ b/internal/generator/template/errors_test.go
@@ -1,0 +1,138 @@
+package template
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestTemplateErrorImplementsError verifies TemplateError implements the error interface
+func TestTemplateErrorImplementsError(t *testing.T) {
+	var _ error = (*TemplateError)(nil)
+}
+
+// TestTemplateErrorMessage tests the Error() method formatting
+func TestTemplateErrorMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateName string
+		err          error
+		wantContains []string
+	}{
+		{
+			name:         "basic error",
+			templateName: "test.tmpl",
+			err:          errors.New("file not found"),
+			wantContains: []string{"template test.tmpl", "file not found"},
+		},
+		{
+			name:         "empty template name",
+			templateName: "",
+			err:          errors.New("parse error"),
+			wantContains: []string{"template ", "parse error"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &TemplateError{
+				Template: tt.templateName,
+				Err:      tt.err,
+			}
+
+			msg := err.Error()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(msg, want) {
+					t.Errorf("TemplateError.Error() = %q, want to contain %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+// TestTemplateErrorUnwrap tests the Unwrap method
+func TestTemplateErrorUnwrap(t *testing.T) {
+	originalErr := errors.New("original error")
+	templateErr := &TemplateError{
+		Template: "test.tmpl",
+		Err:      originalErr,
+	}
+
+	unwrapped := templateErr.Unwrap()
+	if unwrapped != originalErr {
+		t.Errorf("Unwrap() = %v, want %v", unwrapped, originalErr)
+	}
+
+	if !errors.Is(templateErr, originalErr) {
+		t.Error("errors.Is() should return true for wrapped error")
+	}
+}
+
+// TestValidationErrorImplementsError verifies ValidationError implements the error interface
+func TestValidationErrorImplementsError(t *testing.T) {
+	var _ error = (*ValidationError)(nil)
+}
+
+// TestValidationErrorMessage tests the Error() method formatting
+func TestValidationErrorMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateName string
+		field        string
+		message      string
+		wantContains []string
+	}{
+		{
+			name:         "error with field",
+			templateName: "test.tmpl",
+			field:        "ModuleName",
+			message:      "cannot be empty",
+			wantContains: []string{"template test.tmpl", "field ModuleName", "cannot be empty"},
+		},
+		{
+			name:         "error without field",
+			templateName: "test.tmpl",
+			field:        "",
+			message:      "invalid syntax",
+			wantContains: []string{"template test.tmpl", "invalid syntax"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &ValidationError{
+				Template: tt.templateName,
+				Field:    tt.field,
+				Message:  tt.message,
+			}
+
+			msg := err.Error()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(msg, want) {
+					t.Errorf("ValidationError.Error() = %q, want to contain %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+// TestValidationErrorWithoutField tests error message when Field is empty
+func TestValidationErrorWithoutField(t *testing.T) {
+	err := &ValidationError{
+		Template: "test.tmpl",
+		Field:    "",
+		Message:  "template validation failed",
+	}
+
+	msg := err.Error()
+	if strings.Contains(msg, "field :") || strings.Contains(msg, "field  :") {
+		t.Errorf("ValidationError.Error() should not include 'field' when Field is empty, got: %q", msg)
+	}
+
+	wantContains := []string{"template test.tmpl", "template validation failed"}
+	for _, want := range wantContains {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ValidationError.Error() = %q, want to contain %q", msg, want)
+		}
+	}
+}

--- a/internal/generator/template/renderer.go
+++ b/internal/generator/template/renderer.go
@@ -1,0 +1,56 @@
+package template
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// Renderer handles template rendering with variable substitution.
+// It provides methods to render templates from an embedded filesystem,
+// write rendered templates to files, and validate template syntax.
+type Renderer interface {
+	// Render renders a template by name with the given data and returns the result as a string.
+	// The template name should include the .tmpl extension (e.g., "go.mod.tmpl").
+	// Returns an error if the template does not exist or cannot be parsed/executed.
+	Render(name string, data TemplateData) (string, error)
+
+	// RenderToFile renders a template and writes it to the specified output path.
+	// The output path should NOT include the .tmpl extension (e.g., "project/go.mod").
+	// Parent directories will be created automatically if they don't exist.
+	// Returns an error if rendering fails or the file cannot be written.
+	RenderToFile(templateName string, data TemplateData, outputPath string) error
+
+	// Validate checks if a template exists and has valid syntax.
+	// Returns nil if the template is valid, or an error describing the problem.
+	Validate(name string) error
+}
+
+// TemplateRenderer implements Renderer using Go's embed.FS.
+// It reads templates from an embedded filesystem and renders them using text/template.
+type TemplateRenderer struct {
+	fs embed.FS
+}
+
+// NewRenderer creates a new TemplateRenderer that reads templates from the given embed.FS.
+// The embedded filesystem should contain template files with .tmpl extension.
+func NewRenderer(fs embed.FS) Renderer {
+	return &TemplateRenderer{fs: fs}
+}
+
+// Render renders a template by name with the given data and returns the result as a string.
+// This is a stub implementation that will be completed in a later task.
+func (r *TemplateRenderer) Render(name string, data TemplateData) (string, error) {
+	return "", &TemplateError{Template: name, Err: fs.ErrNotExist}
+}
+
+// RenderToFile renders a template and writes it to the specified output path.
+// This is a stub implementation that will be completed in a later task.
+func (r *TemplateRenderer) RenderToFile(templateName string, data TemplateData, outputPath string) error {
+	return &TemplateError{Template: templateName, Err: fs.ErrNotExist}
+}
+
+// Validate checks if a template exists and has valid syntax.
+// This is a stub implementation that will be completed in a later task.
+func (r *TemplateRenderer) Validate(name string) error {
+	return &TemplateError{Template: name, Err: fs.ErrNotExist}
+}

--- a/internal/generator/template/renderer_test.go
+++ b/internal/generator/template/renderer_test.go
@@ -1,0 +1,67 @@
+package template
+
+import (
+	"embed"
+	"testing"
+)
+
+// TestRendererInterface verifies that TemplateRenderer implements the Renderer interface
+func TestRendererInterface(t *testing.T) {
+	var _ Renderer = (*TemplateRenderer)(nil)
+}
+
+// TestNewRenderer tests the NewRenderer constructor function
+func TestNewRenderer(t *testing.T) {
+	var testFS embed.FS
+	renderer := NewRenderer(testFS)
+
+	if renderer == nil {
+		t.Fatal("NewRenderer returned nil")
+	}
+
+	tr, ok := renderer.(*TemplateRenderer)
+	if !ok {
+		t.Fatal("NewRenderer did not return a *TemplateRenderer")
+	}
+
+	if tr.fs != testFS {
+		t.Error("TemplateRenderer.fs not set correctly")
+	}
+}
+
+// TestRendererInterfaceMethods verifies the Renderer interface has the expected methods
+func TestRendererInterfaceMethods(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+	}{
+		{"Render method exists", "Render"},
+		{"RenderToFile method exists", "RenderToFile"},
+		{"Validate method exists", "Validate"},
+	}
+
+	var testFS embed.FS
+	renderer := NewRenderer(testFS)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.method {
+			case "Render":
+				_, err := renderer.Render("test.tmpl", TemplateData{})
+				if err == nil {
+					t.Error("expected error for non-existent template, got nil")
+				}
+			case "RenderToFile":
+				err := renderer.RenderToFile("test.tmpl", TemplateData{}, "/tmp/test")
+				if err == nil {
+					t.Error("expected error for non-existent template, got nil")
+				}
+			case "Validate":
+				err := renderer.Validate("test.tmpl")
+				if err == nil {
+					t.Error("expected error for non-existent template, got nil")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Implements Epic 2, Phase 1: Define Interfaces & Types (#54, #55, #56).

This PR establishes the foundational type system for the template engine with Renderer interface, TemplateData struct, and custom error types.

## Why

Phase 1 of Epic 2 requires defining the core interfaces and types before implementing actual template rendering functionality. This follows the interface-first approach proven successful in Epic 1.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

All implementations are stubs that return appropriate errors until Phase 3 implements actual rendering. This allows the type system to be complete while maintaining clean separation between phases.

Closes #54, #55, #56