### PR TITLE
fix(workflow): add missing checkout step

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,11 @@ jobs:
       id-token: write        # For OAuth authentication
       actions: read          # For CI/CD integration
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## What

Adds checkout step to Claude workflow.

## Why

Workflow was failing with "fatal: not a git repository" because repository wasn't checked out.

## Testing

- [x] Added checkout@v5 with fetch-depth: 0

## Notes

Fixes error from run #18891874943.