### PR TITLE
feat(cli): create commands/ directory structure

### DIFF
--- a/internal/cli/commands/doc.go
+++ b/internal/cli/commands/doc.go
@@ -1,0 +1,24 @@
+// Package commands contains Cobra command implementations with dependency injection.
+//
+// Each command is implemented as a struct with injected dependencies, following
+// the dependency injection pattern for testability:
+//
+//	type NewCommand struct {
+//	    validator interfaces.Validator
+//	    generator interfaces.ProjectGenerator
+//	}
+//
+//	func NewNewCommand(v interfaces.Validator, g interfaces.ProjectGenerator) *NewCommand {
+//	    return &NewCommand{validator: v, generator: g}
+//	}
+//
+//	func (c *NewCommand) Command() *cobra.Command {
+//	    // Returns configured cobra.Command
+//	}
+//
+// This pattern allows:
+//   - Easy mocking of dependencies in tests
+//   - Clear declaration of what each command needs
+//   - Compile-time verification of dependencies
+//   - Reusable command instances
+package commands


### PR DESCRIPTION
## Summary

Implements Issue #155 - Creates the `internal/cli/commands/` directory structure with package documentation.

## Changes

- Created `internal/cli/commands/` directory
- Added `doc.go` with package documentation for dependency injection pattern
- Establishes foundation for separating command logic from root.go

## Acceptance Criteria

- [x] Directory `internal/cli/commands/` exists
- [x] Directory contains a `doc.go` file with package documentation
- [ ] `make lint` passes (needs local verification)
- [ ] `make test` passes (needs local verification)
- [x] No import cycles (verified - only doc file, no imports)

Closes #155

---

Generated with [Claude Code](https://claude.ai/code)