### PR TITLE
fix(workflow): enable Claude to create PRs and use common tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,9 +36,23 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Allow Claude to read CI results
+          # Allow Claude to read CI results and create PRs
           additional_permissions: |
             actions: read
+            Bash(gh pr create:*)
+            Bash(gh pr view:*)
+            Bash(gh issue view:*)
+            Bash(grep:*)
+            Bash(sed:*)
+            Bash(mkdir:*)
+            Bash(find:*)
+            Bash(mv:*)
+            Bash(cp:*)
+            Bash(rm:*)
+            Bash(cat:*)
+            Bash(ls:*)
+            Bash(go:*)
+            Bash(make:*)
 
           # No prompt specified - uses Interactive Mode
           # In Interactive Mode, Claude automatically:


### PR DESCRIPTION
## What

Adds tool permissions to the Claude workflow so the bot can automatically create pull requests and run common development commands.

## Why

The bot successfully implemented issue #155 but couldn't create a PR - it only posted a "Create PR" link. This happened because the workflow didn't allow the bot to run `gh pr create` or other bash commands beyond basic git operations.

## Testing

- [x] Tests pass locally (no code changes)
- [x] Linting passes (workflow YAML only)

## Notes

Added permissions for:
- GitHub CLI (`gh pr create`, `gh pr view`, `gh issue view`)  
- Common bash tools (`grep`, `sed`, `mkdir`, `find`, `mv`, `cp`, `rm`, `cat`, `ls`)
- Go tooling (`go:*`)
- Make targets (`make:*`)

Will verify the bot can create PRs when we assign it the next issue from Epic 0.5.