### PR TITLE
feat: create internal/generator/interfaces/ directory per ADR-002

### DIFF
--- a/internal/generator/interfaces/doc.go
+++ b/internal/generator/interfaces/doc.go
@@ -1,0 +1,9 @@
+// Package interfaces defines consumer-owned interfaces for generator components.
+//
+// Per ADR-002, interfaces should be defined in the consumer package, not the
+// provider package. This enables dependency inversion and loose coupling.
+//
+// The internal/generator package consumes interfaces defined here, while
+// provider packages (such as internal/generator/template) implement these
+// interfaces. This pattern prevents import cycles and follows Go best practices.
+package interfaces


### PR DESCRIPTION
## Summary

Create the `internal/generator/interfaces/` directory with package documentation per ADR-002. This establishes the correct location for generator-owned interfaces before moving template.Renderer in Task 10.

## Changes

- Created `internal/generator/interfaces/doc.go` with package documentation
- Documentation explains consumer-owned interface pattern per ADR-002
- Follows same structure as `internal/cli/interfaces/`

## Testing

- ✓ `make lint-go` passes
- ✓ `make test` passes

Resolves #192

---

Generated with [Claude Code](https://claude.ai/code)