### PR TITLE
fix(ci): add write permissions and bash tool allowlist for claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -92,6 +92,8 @@ jobs:
           # Use sticky comments to reuse same PR comment on each push
           use_sticky_comment: true
 
-          # Use Sonnet 4.5 for reviews
-          claude_args: '--model claude-sonnet-4-5-20250929'
+          # Use Sonnet 4.5 for reviews and allow necessary bash commands
+          claude_args: |
+            --model claude-sonnet-4-5-20250929
+            --allowedTools "Bash(git *),Bash(gh *),Bash(env *),Bash(grep *),Bash(sed *),Bash(find *),Bash(cat *),Bash(head *),Bash(tail *),Bash(awk *),Bash(jq *),Bash(ls *),Bash(make *)"
 


### PR DESCRIPTION
Fixes the Claude Code review workflow so it can actually post review comments.

## Problem
The workflow was running successfully but couldn't post review comments because:
1. Missing `pull-requests: write` permission (had only `read`)
2. Missing bash tool allowlist - Claude couldn't execute git/gh/make commands

From the logs, permission denials prevented:
- Posting review comments to PRs  
- Running `git`, `gh`, `env` commands to inspect PR context
- Running `make lint`, `make test` for verification

## Changes
- **Permissions**: Change `pull-requests` from `read` to `write` (required to post comments)
- **Tool Allowlist**: Add common bash commands via `--allowedTools`:
  - `git *` - inspect git history/diffs
  - `gh *` - interact with GitHub API
  - `make *` - run linting/tests
  - `grep`, `sed`, `find`, `cat`, `head`, `tail`, `awk`, `jq`, `ls`, `env` - analyze code

## Testing
This PR will trigger the workflow with the new permissions. The workflow should successfully post a review comment on this PR.