### PR TITLE
fix(ci): add MCP inline comment tool and GitHub context to claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,8 +38,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Enable progress tracking for visual feedback
+          track_progress: true
+
           # Automated review prompt
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Please review this pull request and provide feedback based on the file types:
 
             **Context: Go 1.24+ Modern Practices**
@@ -92,8 +98,8 @@ jobs:
           # Use sticky comments to reuse same PR comment on each push
           use_sticky_comment: true
 
-          # Use Sonnet 4.5 for reviews and allow necessary bash commands
+          # Use Sonnet 4.5 for reviews and allow necessary bash commands and MCP tools
           claude_args: |
             --model claude-sonnet-4-5-20250929
-            --allowedTools "Bash(git *),Bash(gh *),Bash(env *),Bash(grep *),Bash(sed *),Bash(find *),Bash(cat *),Bash(head *),Bash(tail *),Bash(awk *),Bash(jq *),Bash(ls *),Bash(make *)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(git *),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api *),Bash(env *),Bash(grep *),Bash(sed *),Bash(find *),Bash(cat *),Bash(head *),Bash(tail *),Bash(awk *),Bash(jq *),Bash(ls *),Bash(make *)"
 


### PR DESCRIPTION
## Problem

The Claude Code review workflow runs successfully but doesn't post review comments on PRs.

## Root Cause

After comparing with the official example configurations, we were missing:
1. The MCP inline comment tool that Claude uses to post reviews
2. GitHub repository and PR context variables in the prompt
3. Progress tracking for visual feedback

## Changes

**Added to workflow:**
- `track_progress: true` - Enables visual progress indicators
- Repository and PR context in prompt: `REPO: ${{ github.repository }}` and `PR NUMBER: ${{ github.event.pull_request.number }}`
- `mcp__github_inline_comment__create_inline_comment` - The MCP tool Claude uses to post inline review comments
- More specific gh command patterns: `gh pr comment:*`, `gh pr diff:*`, `gh pr view:*`

**Kept existing:**
- Custom review instructions for Go code and documentation
- `use_sticky_comment: true`
- OAuth token authentication
- Sonnet 4.5 model

## Testing Plan

After this PR merges, we'll test by rebasing PR #199 on main to trigger the workflow with these new settings.

## References

- [Claude Code Action Solutions Guide](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md) - Automatic PR Code Review examples