### PR TITLE
docs: complete Epic 0.5 Phase 5 & 6 remaining tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,45 @@ Hierarchical configuration (lowest to highest priority):
 - PRD docs live in `/docs/prd/`
 - User docs live in `/website/docs/` (Docusaurus)
 
+### Architecture Tests
+
+We use architecture tests to enforce design principles programmatically. These tests run on every `make test` and prevent architectural drift.
+
+**Current Architecture Tests:**
+
+1. **Import Cycle Detection** (`TestNoImportCycles`)
+   - **Purpose:** Prevent circular dependencies
+   - **Method:** Uses `go list -json` to detect cycles
+   - **Location:** `internal/cli/commands/architecture_test.go`
+   - **References:** [ADR-002](./docs/adr/002-interface-placement-consumer-packages.md)
+
+2. **Interface Location Validation** (`TestInterfacesPackageOnlyContainsInterfaces`)
+   - **Purpose:** Enforce "interfaces in consumer packages" rule
+   - **Method:** AST parsing to verify only interfaces in `cli/interfaces/`
+   - **Location:** `internal/cli/interfaces/interfaces_test.go`
+   - **References:** [ADR-002](./docs/adr/002-interface-placement-consumer-packages.md)
+
+3. **DI Pattern Enforcement** (`TestCommandsUseDI`)
+   - **Purpose:** Ensure all commands use dependency injection
+   - **Method:** Pattern matching to verify each `*Command` has `New*Command` constructor
+   - **Location:** `internal/cli/commands/architecture_test.go`
+   - **References:** [ADR-001](./docs/adr/001-dependency-injection-for-cli-commands.md)
+
+**When to Add Architecture Tests:**
+
+- New architectural rule that can be verified programmatically
+- Pattern that must be followed by all new code
+- Design decision that prevents future bugs if enforced
+- When code review alone isn't sufficient to catch violations
+
+**How to Add a New Architecture Test:**
+
+1. Add test function to appropriate `architecture_test.go` file
+2. Use `go list`, AST parsing, or pattern matching as appropriate
+3. Provide clear error messages that explain the violation and reference relevant ADRs
+4. Verify test passes on current codebase
+5. Document the test in this section of CLAUDE.md
+
 ## Commit and PR Guidelines
 
 **See [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed PR process.**

--- a/docs/roadmap/phases/0-foundation/epics/1-cli-infrastructure.md
+++ b/docs/roadmap/phases/0-foundation/epics/1-cli-infrastructure.md
@@ -2,6 +2,8 @@
 
 [← Back to Phase 0](../0-foundation.md)
 
+> **Note:** This epic documents the original CLI implementation (October 2025). The architecture was later enhanced by [Epic 0.5: Architecture Alignment](./0.5-architecture-alignment.md) which added dependency injection, moved interfaces to consumer packages, and established context propagation patterns. See also [ADR-001](../../../adr/001-dependency-injection-for-cli-commands.md), [ADR-002](../../../adr/002-interface-placement-consumer-packages.md), and [ADR-003](../../../adr/003-context-propagation-pattern.md).
+
 ## Overview
 
 Establish the foundational CLI tool using Cobra framework. This epic creates the basic `tracks` command that can be executed, displays version information, and provides help text. This is the absolute foundation that all other epics depend on.
@@ -36,9 +38,11 @@ Establish the foundational CLI tool using Cobra framework. This epic creates the
 
 - Actual command implementations (new, generate, etc.) - those come in later epics
 - Full TUI implementation - deferred to Phase 4
-- Structured logging with zerolog - only for generated apps, not CLI tool
+- Structured logging with zerolog - initially deferred, later added in Epic 0.5 for developer debugging (dual-output strategy: Renderer for stdout, zerolog for stderr)
 - Configuration file loading from tracks.yaml - deferred to later phases (Viper infrastructure ready)
 - Advanced CLI features (autocomplete, etc.)
+- Dependency injection pattern - established later in Epic 0.5
+- Interface placement in consumer packages - moved later in Epic 0.5 per ADR-002
 
 ## Task Breakdown
 
@@ -208,6 +212,8 @@ go build -ldflags "-X main.Version=v0.1.0 -X main.Commit=$(git rev-parse HEAD)"
 
 ### Command Structure
 
+**Original Structure (Epic 1):**
+
 Keep root command minimal. Structure for extensibility:
 
 ```go
@@ -224,9 +230,15 @@ var rootCmd = &cobra.Command{
 }
 ```
 
+> **Epic 0.5 Enhancement:** Commands were moved to `internal/cli/commands/` directory with dependency injection pattern. Each command is now a struct with a constructor (e.g., `NewCommand`, `VersionCommand`) that receives dependencies via constructor parameters. See [ADR-001](../../../adr/001-dependency-injection-for-cli-commands.md) for details.
+
 ### Note on Logging vs Output
 
-The tracks CLI tool uses the Renderer pattern for user-facing output (progress bars, success messages, table data). Structured logging with zerolog is for generated applications (web servers), not the CLI tool itself. This separation keeps the CLI tool friendly for developers while generated apps remain production-ready with structured logs.
+**Original Design (Epic 1):**
+
+The tracks CLI tool uses the Renderer pattern for user-facing output (progress bars, success messages, table data). Structured logging with zerolog was initially only for generated applications (web servers), not the CLI tool itself.
+
+> **Epic 0.5 Enhancement:** Dual-output strategy established - Renderer for stdout (user-facing output), zerolog for stderr (developer debugging controlled by `TRACKS_LOG_LEVEL` environment variable). This keeps the user experience clean while enabling detailed debugging when needed. See [ADR-003](../../../adr/003-context-propagation-pattern.md) for context propagation details.
 
 ### Note on Modern Go Tooling Pattern
 


### PR DESCRIPTION
## What

Completes the remaining documentation and testing tasks from Epic 0.5 Phase 5 & 6:
- Update Epic 1 documentation with Epic 0.5 references (#179)
- Add TestCommandsUseDI architecture test (#183)
- Document architecture test strategy in CLAUDE.md (#184)

## Why

Epic 0.5 introduced significant architectural changes (dependency injection, interface placement, context propagation). The Epic 1 documentation needed updates to reflect these changes and clarify what was original vs. enhanced. Architecture tests enforce these patterns programmatically to prevent drift.

## Testing

- [x] Tests pass locally (`make test`)
- [x] Linting passes (`make lint`)
- [x] TestCommandsUseDI verifies all commands use DI pattern
- [x] All architecture tests pass

## Notes

Epic 1 now has a clear note at the top referencing Epic 0.5 and includes "Epic 0.5 Enhancement" sections showing how the architecture evolved. Architecture test documentation in CLAUDE.md helps developers understand when/how to add new tests.

Closes #179
Closes #183
Closes #184