### PR TITLE
feat: add go.mod template dependencies and tests (#111, #112)

### DIFF
--- a/internal/templates/project/go.mod.tmpl
+++ b/internal/templates/project/go.mod.tmpl
@@ -1,3 +1,19 @@
 module {{.ModuleName}}
 
 go {{.GoVersion}}
+
+require (
+	github.com/go-chi/chi/v5 v5.0.12
+	github.com/a-h/templ v0.2.543
+{{- if eq .DBDriver "go-libsql"}}
+	github.com/tursodatabase/libsql-client-go v0.0.0-20240220085343-4ae0eb9d0898
+{{- else if eq .DBDriver "sqlite3"}}
+	github.com/mattn/go-sqlite3 v1.14.22
+{{- else if eq .DBDriver "postgres"}}
+	github.com/lib/pq v1.10.9
+{{- end}}
+	github.com/pressly/goose/v3 v3.18.0
+	github.com/sqlc-dev/sqlc v1.25.0
+	github.com/alexedwards/scs/v2 v2.7.0
+	github.com/rs/zerolog v1.32.0
+)


### PR DESCRIPTION
## What

Completes the go.mod template implementation and comprehensive testing.

## Changes

**Issue #111 - go.mod template:**
- Added `require` block with core dependencies (Chi, templ, goose, sqlc, scs, zerolog)
- Added conditional logic for database drivers using template syntax
- Supports all three database drivers: go-libsql, sqlite3, postgres

**Issue #112 - Comprehensive tests:**
- Expanded `TestGoModTemplate` to test all three database drivers
- Verifies all core dependencies appear in output
- Verifies only the selected database driver is included
- Tests different module paths and Go versions

## Testing

- All tests pass (4 test cases covering all 3 database drivers)
- Lint passes
- Template renders correctly with all database driver options

## Notes

- Template uses `{{- if eq .DBDriver "driver-name"}}` syntax for conditional inclusion
- Tests verify both presence of required deps and absence of non-selected drivers
- Follows existing test patterns in templates_test.go

Closes #111
Closes #112