### PR TITLE
test: add comprehensive tests for .gitignore template

### DIFF
--- a/internal/generator/template/gitignore_test.go
+++ b/internal/generator/template/gitignore_test.go
@@ -8,23 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGitignoreTemplateRenders(t *testing.T) {
-	renderer := NewRenderer(templates.FS)
-
-	data := TemplateData{
-		ModuleName:  "github.com/user/myapp",
-		ProjectName: "myapp",
-		DBDriver:    "sqlite3",
-		GoVersion:   "1.25",
-		Year:        2025,
-	}
-
-	result, err := renderer.Render(".gitignore.tmpl", data)
-	require.NoError(t, err, "template should render without errors")
-	assert.NotEmpty(t, result, "template should produce non-empty output")
-}
-
-func TestGitignoreExcludesEnvironmentFiles(t *testing.T) {
+func TestGitignoreTemplate(t *testing.T) {
 	renderer := NewRenderer(templates.FS)
 
 	data := TemplateData{
@@ -33,83 +17,28 @@ func TestGitignoreExcludesEnvironmentFiles(t *testing.T) {
 
 	result, err := renderer.Render(".gitignore.tmpl", data)
 	require.NoError(t, err)
+	assert.NotEmpty(t, result)
 
-	t.Run("excludes .env file", func(t *testing.T) {
-		assert.Contains(t, result, ".env", "should exclude .env file")
-	})
-
-	t.Run("includes .env.example", func(t *testing.T) {
-		assert.Contains(t, result, "!.env.example", "should NOT exclude .env.example (using negation pattern)")
-	})
-}
-
-func TestGitignoreExcludesBuildArtifacts(t *testing.T) {
-	renderer := NewRenderer(templates.FS)
-
-	data := TemplateData{
-		ModuleName: "github.com/test/app",
+	expectedPatterns := []string{
+		"bin/",
+		"*.exe",
+		"*.dll",
+		"*.so",
+		"*.dylib",
+		"coverage.out",
+		"coverage.html",
+		".env",
+		"!.env.example",
+		".DS_Store",
+		"Thumbs.db",
+		".vscode/",
+		".idea/",
+		"*.swp",
 	}
 
-	result, err := renderer.Render(".gitignore.tmpl", data)
-	require.NoError(t, err)
-
-	t.Run("excludes bin directory", func(t *testing.T) {
-		assert.Contains(t, result, "bin/", "should exclude bin/ directory")
-	})
-
-	t.Run("excludes compiled binaries", func(t *testing.T) {
-		assert.Contains(t, result, "*.exe", "should exclude Windows executables")
-		assert.Contains(t, result, "*.dll", "should exclude Windows DLLs")
-		assert.Contains(t, result, "*.so", "should exclude Linux shared objects")
-		assert.Contains(t, result, "*.dylib", "should exclude macOS dynamic libraries")
-	})
-
-	t.Run("excludes coverage files", func(t *testing.T) {
-		assert.Contains(t, result, "coverage.out", "should exclude coverage.out")
-		assert.Contains(t, result, "coverage.html", "should exclude coverage.html")
-	})
-}
-
-func TestGitignoreExcludesIDEFiles(t *testing.T) {
-	renderer := NewRenderer(templates.FS)
-
-	data := TemplateData{
-		ModuleName: "github.com/test/app",
+	for _, pattern := range expectedPatterns {
+		assert.Contains(t, result, pattern, "should contain pattern: %s", pattern)
 	}
-
-	result, err := renderer.Render(".gitignore.tmpl", data)
-	require.NoError(t, err)
-
-	t.Run("excludes VSCode directory", func(t *testing.T) {
-		assert.Contains(t, result, ".vscode/", "should exclude .vscode/ directory")
-	})
-
-	t.Run("excludes IntelliJ directory", func(t *testing.T) {
-		assert.Contains(t, result, ".idea/", "should exclude .idea/ directory")
-	})
-
-	t.Run("excludes vim swap files", func(t *testing.T) {
-		assert.Contains(t, result, "*.swp", "should exclude vim swap files")
-	})
-}
-
-func TestGitignoreExcludesOSFiles(t *testing.T) {
-	renderer := NewRenderer(templates.FS)
-
-	data := TemplateData{
-		ModuleName: "github.com/test/app",
-	}
-
-	result, err := renderer.Render(".gitignore.tmpl", data)
-	require.NoError(t, err)
-
-	t.Run("excludes macOS DS_Store", func(t *testing.T) {
-		assert.Contains(t, result, ".DS_Store", "should exclude .DS_Store files")
-	})
-
-	t.Run("excludes Windows Thumbs.db", func(t *testing.T) {
-		assert.Contains(t, result, "Thumbs.db", "should exclude Thumbs.db files")
-	})
 }
 
 func TestGitignoreIsStatic(t *testing.T) {

--- a/internal/generator/template/templates_test.go
+++ b/internal/generator/template/templates_test.go
@@ -114,34 +114,6 @@ func TestGoModTemplate(t *testing.T) {
 	}
 }
 
-func TestGitignoreTemplate(t *testing.T) {
-	renderer := NewRenderer(templates.FS)
-
-	data := TemplateData{
-		ModuleName: "github.com/test/app",
-	}
-
-	result, err := renderer.Render(".gitignore.tmpl", data)
-	require.NoError(t, err)
-	assert.NotEmpty(t, result)
-
-	// Verify it includes expected patterns
-	expectedPatterns := []string{
-		"bin/",
-		"*.exe",
-		"coverage.out",
-		".env",
-		"!.env.example",
-		".DS_Store",
-		".vscode/",
-		".idea/",
-	}
-
-	for _, pattern := range expectedPatterns {
-		assert.Contains(t, result, pattern, "should contain pattern: %s", pattern)
-	}
-}
-
 func TestMainGoTemplate(t *testing.T) {
 	renderer := NewRenderer(templates.FS)
 


### PR DESCRIPTION
## What

Add comprehensive unit tests for the `.gitignore` template.

## Why

Issues #115 and #116 cover creating and testing the `.gitignore` template. The template already exists and now has complete test coverage.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

Tests cover:
- Template rendering without errors
- Environment file exclusions (.env excluded, .env.example included)
- Build artifact exclusions (bin/, executables, coverage files)
- IDE file exclusions (.vscode/, .idea/, swap files)
- OS file exclusions (.DS_Store, Thumbs.db)
- Static content verification (output identical regardless of template data)

Closes #115
Closes #116