### PR TITLE
feat: enhance .env.example template with driver-specific URLs

### DIFF
--- a/internal/generator/template/env_example_test.go
+++ b/internal/generator/template/env_example_test.go
@@ -1,0 +1,171 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvExampleTemplate(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	tests := []struct {
+		name        string
+		projectName string
+		dbDriver    string
+		expectedURL string
+	}{
+		{
+			name:        "go-libsql driver",
+			projectName: "myapp",
+			dbDriver:    "go-libsql",
+			expectedURL: "DATABASE_URL=file:./myapp.db",
+		},
+		{
+			name:        "sqlite3 driver",
+			projectName: "testapp",
+			dbDriver:    "sqlite3",
+			expectedURL: "DATABASE_URL=./testapp.db",
+		},
+		{
+			name:        "postgres driver",
+			projectName: "webapp",
+			dbDriver:    "postgres",
+			expectedURL: "DATABASE_URL=postgres://localhost/webapp?sslmode=disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := TemplateData{
+				ProjectName: tt.projectName,
+				DBDriver:    tt.dbDriver,
+			}
+
+			result, err := renderer.Render(".env.example.tmpl", data)
+			require.NoError(t, err)
+			assert.NotEmpty(t, result)
+
+			assert.Contains(t, result, "⚠️")
+			assert.Contains(t, result, "WARNING")
+			assert.Contains(t, result, "NEVER COMMIT")
+
+			assert.Contains(t, result, tt.expectedURL)
+
+			assert.Contains(t, result, "SECRET_KEY=")
+			assert.Contains(t, result, "APP_ENV=")
+			assert.Contains(t, result, "LOG_LEVEL=")
+			assert.Contains(t, result, "PORT=")
+		})
+	}
+}
+
+func TestEnvExampleSecurityWarning(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "myapp",
+		DBDriver:    "sqlite3",
+	}
+
+	result, err := renderer.Render(".env.example.tmpl", data)
+	require.NoError(t, err)
+
+	expectedWarnings := []string{
+		"⚠️",
+		"WARNING",
+		"NEVER COMMIT",
+		".env",
+		"VERSION CONTROL",
+		"gitignored",
+		"secrets",
+	}
+
+	for _, warning := range expectedWarnings {
+		assert.Contains(t, result, warning, "should contain security warning: %s", warning)
+	}
+}
+
+func TestEnvExampleRequiredVariables(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "myapp",
+		DBDriver:    "sqlite3",
+	}
+
+	result, err := renderer.Render(".env.example.tmpl", data)
+	require.NoError(t, err)
+
+	requiredVariables := []string{
+		"APP_ENV=",
+		"LOG_LEVEL=",
+		"PORT=",
+		"DATABASE_URL=",
+		"SECRET_KEY=",
+	}
+
+	for _, variable := range requiredVariables {
+		assert.Contains(t, result, variable, "should contain variable: %s", variable)
+	}
+}
+
+func TestEnvExampleSecretKeyGuidance(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "myapp",
+		DBDriver:    "sqlite3",
+	}
+
+	result, err := renderer.Render(".env.example.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "SECRET_KEY=")
+	assert.Contains(t, result, "openssl rand")
+	assert.Contains(t, result, "replace")
+}
+
+func TestEnvExampleDifferentProjectNames(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	tests := []struct {
+		projectName string
+		driver      string
+	}{
+		{"myapp", "go-libsql"},
+		{"cool-project", "sqlite3"},
+		{"web-service", "postgres"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.projectName, func(t *testing.T) {
+			data := TemplateData{
+				ProjectName: tt.projectName,
+				DBDriver:    tt.driver,
+			}
+
+			result, err := renderer.Render(".env.example.tmpl", data)
+			require.NoError(t, err)
+
+			assert.Contains(t, result, tt.projectName, "database URL should contain project name")
+		})
+	}
+}
+
+func TestEnvExamplePostgresSecurityNote(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "myapp",
+		DBDriver:    "postgres",
+	}
+
+	result, err := renderer.Render(".env.example.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "production")
+	assert.Contains(t, result, "sslmode")
+}

--- a/internal/generator/template/templates_test.go
+++ b/internal/generator/template/templates_test.go
@@ -259,30 +259,6 @@ func TestTracksYamlTemplate(t *testing.T) {
 	}
 }
 
-func TestEnvExampleTemplate(t *testing.T) {
-	renderer := NewRenderer(templates.FS)
-
-	data := TemplateData{
-		ModuleName: "github.com/test/app",
-	}
-
-	result, err := renderer.Render(".env.example.tmpl", data)
-	require.NoError(t, err)
-	assert.NotEmpty(t, result)
-
-	// Verify security warnings
-	assert.Contains(t, result, "WARNING")
-	assert.Contains(t, result, "NEVER commit .env")
-
-	// Verify expected environment variables
-	assert.Contains(t, result, "DATABASE_URL")
-	assert.Contains(t, result, "PORT")
-
-	// Verify placeholder values
-	assert.Contains(t, result, "sqlite://data/app.db")
-	assert.Contains(t, result, "8080")
-}
-
 func TestReadmeTemplate(t *testing.T) {
 	renderer := NewRenderer(templates.FS)
 

--- a/internal/templates/project/.env.example.tmpl
+++ b/internal/templates/project/.env.example.tmpl
@@ -1,8 +1,29 @@
-# WARNING: This is an example file. Copy to .env and fill in real values.
-# NEVER commit .env to version control!
+# ⚠️  WARNING: NEVER COMMIT .env FILES TO VERSION CONTROL! ⚠️
+#
+# This is an example file. Copy it to .env and fill in your real values:
+#   cp .env.example .env
+#
+# The .env file is gitignored to prevent accidentally committing secrets.
+
+# Application environment (development, staging, production)
+APP_ENV=development
+
+# Log level (debug, info, warn, error)
+LOG_LEVEL=debug
+
+# Server port
+PORT=8080
 
 # Database connection URL
-DATABASE_URL=sqlite://data/app.db
+{{- if eq .DBDriver "go-libsql"}}
+DATABASE_URL=file:./{{.ProjectName}}.db
+{{- else if eq .DBDriver "sqlite3"}}
+DATABASE_URL=./{{.ProjectName}}.db
+{{- else if eq .DBDriver "postgres"}}
+# For production, use a connection string without sslmode=disable
+DATABASE_URL=postgres://localhost/{{.ProjectName}}?sslmode=disable
+{{- end}}
 
-# Server configuration
-PORT=8080
+# Session secret key for encrypting cookies
+# Generate a secure random key: openssl rand -base64 32
+SECRET_KEY=your-secret-key-here-replace-with-secure-random-value


### PR DESCRIPTION
## What

Enhance the `.env.example` template with prominent security warnings, driver-specific database URLs, and comprehensive unit tests.

## Why

Issues #117 and #118 require a production-ready template that prevents security issues by clearly warning users about secrets and providing correct configuration examples for each database driver.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

Template changes:
- Prominent ⚠️ security warning
- Driver-specific DATABASE_URL examples (go-libsql, sqlite3, postgres)
- Added SECRET_KEY with generation instructions
- Added APP_ENV, LOG_LEVEL, PORT variables

Test coverage:
- 6 test functions covering all drivers, security warnings, required variables, and project name substitution
- Removed duplicate test from templates_test.go

Closes #117
Closes #118