### PR TITLE
feat: add mockery config template with tests

### DIFF
--- a/internal/generator/template/mockery_yaml_test.go
+++ b/internal/generator/template/mockery_yaml_test.go
@@ -1,0 +1,169 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMockeryYamlTemplate(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+}
+
+func TestMockeryYamlValidYAML(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err, "generated YAML should be valid")
+}
+
+func TestMockeryYamlRequiredFields(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	requiredFields := []string{"with-expecter", "dir", "output", "outpkg", "all"}
+	for _, field := range requiredFields {
+		assert.Contains(t, config, field, "should contain required field: %s", field)
+	}
+}
+
+func TestMockeryYamlWithExpecterTrue(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, config["with-expecter"], "with-expecter should be true")
+}
+
+func TestMockeryYamlDirectoryPath(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "internal/interfaces", config["dir"], "dir should be internal/interfaces")
+}
+
+func TestMockeryYamlOutputPath(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	output, ok := config["output"].(string)
+	require.True(t, ok, "output should be a string")
+	assert.Contains(t, output, "test/mocks/", "output should include test/mocks/ directory")
+	assert.Contains(t, output, ".InterfaceName", "output should include .InterfaceName placeholder")
+}
+
+func TestMockeryYamlPackageName(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "mocks", config["outpkg"], "outpkg should be mocks")
+}
+
+func TestMockeryYamlAutoDiscovery(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName: "github.com/test/app",
+	}
+
+	result, err := renderer.Render(".mockery.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, config["all"], "all should be true for auto-discovery")
+}
+
+func TestMockeryYamlIsStatic(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data1 := TemplateData{
+		ModuleName:  "github.com/test/app1",
+		ProjectName: "project1",
+		DBDriver:    "postgres",
+	}
+
+	data2 := TemplateData{
+		ModuleName:  "gitlab.com/org/app2",
+		ProjectName: "project2",
+		DBDriver:    "sqlite3",
+	}
+
+	result1, err := renderer.Render(".mockery.yaml.tmpl", data1)
+	require.NoError(t, err)
+
+	result2, err := renderer.Render(".mockery.yaml.tmpl", data2)
+	require.NoError(t, err)
+
+	assert.Equal(t, result1, result2, "template should produce identical output regardless of template data")
+}

--- a/internal/templates/project/.mockery.yaml.tmpl
+++ b/internal/templates/project/.mockery.yaml.tmpl
@@ -1,0 +1,15 @@
+# Mockery auto-generates test mocks from interfaces to eliminate hand-rolled duplicates
+# Docs: https://vektra.github.io/mockery/latest/configuration/
+
+# Expecter pattern provides fluent mock expectations API for more readable tests
+with-expecter: true
+
+# Discover interfaces in internal/interfaces (consumer-package pattern prevents import cycles)
+dir: "internal/interfaces"
+
+# Centralized mocks directory simplifies imports across all test files
+output: "test/mocks/{{"{{"}} .InterfaceName {{"}}"}}.go"
+outpkg: mocks
+
+# Auto-discover all interfaces (no manual registration, convention over configuration)
+all: true


### PR DESCRIPTION
## What

Implements issues #127 and #128 for mockery configuration template and comprehensive tests.

## Why

Enables auto-generation of test mocks from interfaces per ADR-004 in generated Tracks projects.

## Testing

- [x] Tests pass locally (9 test functions)
- [x] Linting passes (`make lint`)

## Notes

Configuration points to `internal/interfaces/` for zero-dependency interface discovery and outputs mocks to `test/mocks/`. Enables testify expecter pattern with `with-expecter: true` for powerful mock assertions.

Closes #127
Closes #128