### PR TITLE
feat: add sqlc.yaml template (#135)

### DIFF
--- a/internal/generator/template/sqlc_yaml_test.go
+++ b/internal/generator/template/sqlc_yaml_test.go
@@ -1,0 +1,343 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSqlcYamlTemplate(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	drivers := []string{"go-libsql", "sqlite3", "postgres"}
+
+	for _, driver := range drivers {
+		t.Run(driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+			assert.NotEmpty(t, result)
+		})
+	}
+}
+
+func TestSqlcYamlValidYAML(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	drivers := []string{"go-libsql", "sqlite3", "postgres"}
+
+	for _, driver := range drivers {
+		t.Run(driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err, "generated YAML should be valid for %s", driver)
+		})
+	}
+}
+
+func TestSqlcYamlVersion(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		DBDriver: "postgres",
+	}
+
+	result, err := renderer.Render("sqlc.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2", config["version"], "version should be 2")
+}
+
+func TestSqlcYamlSchemaPath(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	tests := []struct {
+		driver         string
+		expectedSchema string
+	}{
+		{"go-libsql", "db/migrations/sqlite"},
+		{"sqlite3", "db/migrations/sqlite"},
+		{"postgres", "db/migrations/postgres"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: tt.driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err)
+
+			sql, ok := config["sql"].([]interface{})
+			require.True(t, ok, "sql should be an array")
+			require.Len(t, sql, 1, "sql array should have one element")
+
+			sqlConfig, ok := sql[0].(map[string]interface{})
+			require.True(t, ok, "sql[0] should be a map")
+
+			assert.Equal(t, tt.expectedSchema, sqlConfig["schema"], "schema path should be correct for %s", tt.driver)
+		})
+	}
+}
+
+func TestSqlcYamlEngine(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	tests := []struct {
+		driver         string
+		expectedEngine string
+	}{
+		{"go-libsql", "sqlite"},
+		{"sqlite3", "sqlite"},
+		{"postgres", "postgresql"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: tt.driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err)
+
+			sql, ok := config["sql"].([]interface{})
+			require.True(t, ok, "sql should be an array")
+
+			sqlConfig, ok := sql[0].(map[string]interface{})
+			require.True(t, ok, "sql[0] should be a map")
+
+			assert.Equal(t, tt.expectedEngine, sqlConfig["engine"], "engine should be %s for driver %s", tt.expectedEngine, tt.driver)
+		})
+	}
+}
+
+func TestSqlcYamlQueriesPath(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	drivers := []string{"go-libsql", "sqlite3", "postgres"}
+
+	for _, driver := range drivers {
+		t.Run(driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err)
+
+			sql, ok := config["sql"].([]interface{})
+			require.True(t, ok, "sql should be an array")
+
+			sqlConfig, ok := sql[0].(map[string]interface{})
+			require.True(t, ok, "sql[0] should be a map")
+
+			assert.Equal(t, "db/queries", sqlConfig["queries"], "queries path should be db/queries for %s", driver)
+		})
+	}
+}
+
+func TestSqlcYamlOutputPath(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	drivers := []string{"go-libsql", "sqlite3", "postgres"}
+
+	for _, driver := range drivers {
+		t.Run(driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err)
+
+			sql, ok := config["sql"].([]interface{})
+			require.True(t, ok, "sql should be an array")
+
+			sqlConfig, ok := sql[0].(map[string]interface{})
+			require.True(t, ok, "sql[0] should be a map")
+
+			gen, ok := sqlConfig["gen"].(map[string]interface{})
+			require.True(t, ok, "gen should be a map")
+
+			goGen, ok := gen["go"].(map[string]interface{})
+			require.True(t, ok, "gen.go should be a map")
+
+			assert.Equal(t, "db/generated", goGen["out"], "output path should be db/generated for %s", driver)
+		})
+	}
+}
+
+func TestSqlcYamlPackageName(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	drivers := []string{"go-libsql", "sqlite3", "postgres"}
+
+	for _, driver := range drivers {
+		t.Run(driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err)
+
+			sql, ok := config["sql"].([]interface{})
+			require.True(t, ok, "sql should be an array")
+
+			sqlConfig, ok := sql[0].(map[string]interface{})
+			require.True(t, ok, "sql[0] should be a map")
+
+			gen, ok := sqlConfig["gen"].(map[string]interface{})
+			require.True(t, ok, "gen should be a map")
+
+			goGen, ok := gen["go"].(map[string]interface{})
+			require.True(t, ok, "gen.go should be a map")
+
+			assert.Equal(t, "generated", goGen["package"], "package name should be generated for %s", driver)
+		})
+	}
+}
+
+func TestSqlcYamlSqlPackage(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	drivers := []string{"go-libsql", "sqlite3", "postgres"}
+
+	for _, driver := range drivers {
+		t.Run(driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err)
+
+			sql, ok := config["sql"].([]interface{})
+			require.True(t, ok, "sql should be an array")
+
+			sqlConfig, ok := sql[0].(map[string]interface{})
+			require.True(t, ok, "sql[0] should be a map")
+
+			gen, ok := sqlConfig["gen"].(map[string]interface{})
+			require.True(t, ok, "gen should be a map")
+
+			goGen, ok := gen["go"].(map[string]interface{})
+			require.True(t, ok, "gen.go should be a map")
+
+			assert.Equal(t, "database/sql", goGen["sql_package"], "sql_package should be database/sql for %s", driver)
+		})
+	}
+}
+
+func TestSqlcYamlEmitFlags(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	drivers := []string{"go-libsql", "sqlite3", "postgres"}
+
+	for _, driver := range drivers {
+		t.Run(driver, func(t *testing.T) {
+			data := TemplateData{
+				DBDriver: driver,
+			}
+
+			result, err := renderer.Render("sqlc.yaml.tmpl", data)
+			require.NoError(t, err)
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal([]byte(result), &config)
+			require.NoError(t, err)
+
+			sql, ok := config["sql"].([]interface{})
+			require.True(t, ok, "sql should be an array")
+
+			sqlConfig, ok := sql[0].(map[string]interface{})
+			require.True(t, ok, "sql[0] should be a map")
+
+			gen, ok := sqlConfig["gen"].(map[string]interface{})
+			require.True(t, ok, "gen should be a map")
+
+			goGen, ok := gen["go"].(map[string]interface{})
+			require.True(t, ok, "gen.go should be a map")
+
+			assert.Equal(t, true, goGen["emit_json_tags"], "emit_json_tags should be true for %s", driver)
+			assert.Equal(t, true, goGen["emit_interface"], "emit_interface should be true for %s", driver)
+			assert.Equal(t, true, goGen["emit_empty_slices"], "emit_empty_slices should be true for %s", driver)
+		})
+	}
+}
+
+func TestSqlcYamlStructure(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		DBDriver: "postgres",
+	}
+
+	result, err := renderer.Render("sqlc.yaml.tmpl", data)
+	require.NoError(t, err)
+
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(result), &config)
+	require.NoError(t, err)
+
+	// Top level should have version and sql
+	assert.Contains(t, config, "version", "config should have version")
+	assert.Contains(t, config, "sql", "config should have sql")
+
+	// SQL should be an array with one element
+	sql, ok := config["sql"].([]interface{})
+	require.True(t, ok, "sql should be an array")
+	require.Len(t, sql, 1, "sql array should have one element")
+
+	// SQL element should have required fields
+	sqlConfig, ok := sql[0].(map[string]interface{})
+	require.True(t, ok, "sql[0] should be a map")
+
+	requiredFields := []string{"schema", "queries", "engine", "gen"}
+	for _, field := range requiredFields {
+		assert.Contains(t, sqlConfig, field, "sql config should have %s field", field)
+	}
+}

--- a/internal/templates/project/sqlc.yaml.tmpl
+++ b/internal/templates/project/sqlc.yaml.tmpl
@@ -1,0 +1,16 @@
+# SQLC configuration for type-safe database code generation
+# Docs: https://docs.sqlc.dev/en/latest/reference/config.html
+
+version: "2"
+sql:
+  - schema: "db/migrations/{{if eq .DBDriver "postgres"}}postgres{{else}}sqlite{{end}}"
+    queries: "db/queries"
+    engine: "{{if eq .DBDriver "postgres"}}postgresql{{else}}sqlite{{end}}"
+    gen:
+      go:
+        package: "generated"
+        out: "db/generated"
+        sql_package: "database/sql"
+        emit_json_tags: true
+        emit_interface: true
+        emit_empty_slices: true


### PR DESCRIPTION
## What

SQLC v2 config template with multi-driver support.

## Why

Enables type-safe database code generation for all three supported drivers (go-libsql, sqlite3, postgres).

## Testing

- [x] Tests pass locally (10 test functions, 40+ cases)
- [x] Linting passes (`make lint`)

## Notes

Conditional schema paths and engine mapping. Output to `db/generated` with all required emit flags.