### PR TITLE
feat: make dev auto-starts docker-compose services (#245)

### DIFF
--- a/internal/generator/template/makefile_test.go
+++ b/internal/generator/template/makefile_test.go
@@ -31,7 +31,7 @@ func TestMakefileTargets(t *testing.T) {
 		items []string
 	}{
 		{"phony declarations", []string{
-			".PHONY: help test build dev dev-services dev-full dev-down generate mocks sqlc lint clean",
+			".PHONY: help test build dev dev-services dev-down generate mocks sqlc lint clean",
 		}},
 		{"help target", []string{
 			"help: ## Show this help message",
@@ -47,7 +47,9 @@ func TestMakefileTargets(t *testing.T) {
 			"go build -o bin/server ./cmd/server",
 		}},
 		{"dev target", []string{
-			"dev: ## Start development server with hot reload",
+			"dev: ## Start development server (auto-starts services if needed)",
+			"grep -q '^  [a-z]' docker-compose.yml",
+			"docker-compose up -d",
 			"go tool air -c .air.toml",
 		}},
 		{"mocks target", []string{
@@ -82,9 +84,8 @@ func TestMakefileHelpText(t *testing.T) {
 		"help         - Show this help message",
 		"test         - Run all tests",
 		"build        - Build the server binary",
-		"dev          - Start development server with hot reload",
+		"dev          - Start development server (auto-starts services if needed)",
 		"dev-services - Start docker-compose services",
-		"dev-full     - Start docker services and dev server",
 		"dev-down     - Stop docker-compose services",
 		"generate     - Generate mocks and SQL code",
 		"mocks        - Generate mocks from interfaces",

--- a/internal/templates/project/Makefile.tmpl
+++ b/internal/templates/project/Makefile.tmpl
@@ -1,13 +1,12 @@
-.PHONY: help test build dev dev-services dev-full dev-down generate mocks sqlc lint clean
+.PHONY: help test build dev dev-services dev-down generate mocks sqlc lint clean
 
 help: ## Show this help message
 	@echo "Available targets:"
 	@echo "  help         - Show this help message"
 	@echo "  test         - Run all tests"
 	@echo "  build        - Build the server binary"
-	@echo "  dev          - Start development server with hot reload"
+	@echo "  dev          - Start development server (auto-starts services if needed)"
 	@echo "  dev-services - Start docker-compose services"
-	@echo "  dev-full     - Start docker services and dev server"
 	@echo "  dev-down     - Stop docker-compose services"
 	@echo "  generate     - Generate mocks and SQL code"
 	@echo "  mocks        - Generate mocks from interfaces"
@@ -22,16 +21,17 @@ build: ## Build server binary
 	@mkdir -p bin
 	go build -o bin/server ./cmd/server
 
-dev: ## Start development server with hot reload
+dev: ## Start development server (auto-starts services if needed)
+	@if grep -q '^  [a-z]' docker-compose.yml 2>/dev/null; then \
+		echo "Starting services..."; \
+		docker-compose up -d; \
+		sleep 2; \
+	fi
+	@echo "Starting dev server..."
 	go tool air -c .air.toml
 
 dev-services: ## Start docker-compose services
 	docker-compose up -d
-
-dev-full: dev-services ## Start docker services and dev server
-	@echo "Services started. Starting development server..."
-	@sleep 2
-	go tool air -c .air.toml
 
 dev-down: ## Stop docker-compose services
 	docker-compose down

--- a/tests/integration/generator_test.go
+++ b/tests/integration/generator_test.go
@@ -164,6 +164,15 @@ func TestGenerateFullProject(t *testing.T) {
 			assert.NotContains(t, string(envContent), "SECRET_KEY=your-secret-key-here", ".env should not contain placeholder secret key")
 			assert.Regexp(t, `SECRET_KEY=[A-Za-z0-9+/]{43}=`, string(envContent), ".env should contain valid base64-encoded secret key (44 chars)")
 
+			makefilePath := filepath.Join(projectRoot, "Makefile")
+			makefileContent, err := os.ReadFile(makefilePath)
+			require.NoError(t, err, "should be able to read Makefile")
+
+			assert.Contains(t, string(makefileContent), "grep -q '^  [a-z]' docker-compose.yml", "Makefile should contain auto-start logic")
+			assert.Contains(t, string(makefileContent), "docker-compose up -d", "Makefile should auto-start services")
+			assert.NotContains(t, string(makefileContent), "dev-full:", "Makefile should not contain dev-full target")
+			assert.NotContains(t, string(makefileContent), "dev-full     - Start docker services and dev server", "Makefile help should not mention dev-full")
+
 			dockerignorePath := filepath.Join(projectRoot, ".dockerignore")
 			dockerignoreContent, err := os.ReadFile(dockerignorePath)
 			require.NoError(t, err, "should be able to read .dockerignore")


### PR DESCRIPTION
## What

Modified the `make dev` target in generated projects to automatically detect and start docker-compose services if needed. Removed the `dev-full` target.

## Why

Improves developer experience by eliminating manual `make dev-services` step. Developers can now run `make dev` directly and services will start automatically if needed.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

Uses `grep -q '^  [a-z]' docker-compose.yml` to detect service definitions. Works correctly for all database drivers:
- postgres and go-libsql: auto-starts services
- sqlite3: no services to start (file-based)

Closes #245 

Implementation is idempotent - safe to run `make dev` multiple times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)