### PR TITLE
docs: mark Epic 1.1 complete and add issue links to Epic 1.2

### DIFF
--- a/docs/roadmap/phases/1-core-web/epics/1.1-chi-router-setup.md
+++ b/docs/roadmap/phases/1-core-web/epics/1.1-chi-router-setup.md
@@ -2,6 +2,10 @@
 
 [← Back to Phase 1](../1-core-web.md)
 
+**Status:** ✅ **COMPLETE** (Completed: November 2025)
+
+[View all closed issues →](https://github.com/anomalousventures/tracks/milestone/1?closed=1)
+
 ## Overview
 
 Create templates and generator logic to produce Chi-based HTTP servers in generated projects. This epic implements the template files for server structure with builder-pattern dependency injection, graceful shutdown handling, and route registration system following a HYPERMEDIA-first philosophy (serving HTML via templ, not JSON APIs). The ProjectGenerator will render these templates when running `tracks new`, creating a production-ready HTTP server foundation.

--- a/docs/roadmap/phases/1-core-web/epics/1.2-templ-templates.md
+++ b/docs/roadmap/phases/1-core-web/epics/1.2-templ-templates.md
@@ -47,68 +47,68 @@ The following tasks will become GitHub issues, ordered by dependency:
 
 ### Phase 1: View Structure Templates (Tasks 1-10)
 
-1. Create view directory structure template
-2. Create base.templ layout template
-3. Create home.templ page template
-4. Create about.templ page template
-5. Create error.templ page template (404, 500)
-6. Create helpers.go template with ClassNames, SafeHTML functions
-7. Create .templignore template
-8. Add templ to go.mod tool directive template
-9. Add templ generation to Makefile template
-10. Create meta.templ component template
+1. [#303](https://github.com/anomalousventures/tracks/issues/303) - Create view directory structure template (`internal/http/views/` with subdirs: `layouts/`, `pages/`, `components/`, and `helpers.go`)
+2. [#304](https://github.com/anomalousventures/tracks/issues/304) - Create base.templ layout template
+3. [#305](https://github.com/anomalousventures/tracks/issues/305) - Create home.templ page template
+4. [#306](https://github.com/anomalousventures/tracks/issues/306) - Create about.templ page template
+5. [#307](https://github.com/anomalousventures/tracks/issues/307) - Create error.templ page template (404, 500)
+6. [#308](https://github.com/anomalousventures/tracks/issues/308) - Create helpers.go template with ClassNames, SafeHTML functions
+7. [#309](https://github.com/anomalousventures/tracks/issues/309) - Create .templignore template
+8. [#310](https://github.com/anomalousventures/tracks/issues/310) - Verify templ dependency in go.mod template (already present in tool directive)
+9. [#311](https://github.com/anomalousventures/tracks/issues/311) - Add templ generation command to Makefile generate target chain
+10. [#312](https://github.com/anomalousventures/tracks/issues/312) - Create meta.templ component template
 
 ### Phase 2: Handler Integration Templates (Tasks 11-20)
 
-1. Create handler template that renders templ components
-2. Update home handler template to use templ
-3. Update about handler template to use templ
-4. Create error handler template with templ rendering
-5. Create context helper template for template data
-6. Create render helper template for common patterns
-7. Update routes.go template to register new handlers
-8. Create handler_test.go template for templ rendering tests
-9. Create integration test template for full page rendering
-10. Document handler-to-template integration in generated README
+1. [#313](https://github.com/anomalousventures/tracks/issues/313) - Create handler template that renders templ components
+2. [#314](https://github.com/anomalousventures/tracks/issues/314) - Create home handler template using templ rendering
+3. [#315](https://github.com/anomalousventures/tracks/issues/315) - Create about handler template using templ rendering
+4. [#316](https://github.com/anomalousventures/tracks/issues/316) - Create error handler template with templ rendering
+5. [#317](https://github.com/anomalousventures/tracks/issues/317) - Create context helper template for template data
+6. [#318](https://github.com/anomalousventures/tracks/issues/318) - Create render helper template for common patterns
+7. [#319](https://github.com/anomalousventures/tracks/issues/319) - Update routes.go template to register new handlers
+8. [#320](https://github.com/anomalousventures/tracks/issues/320) - Create handler_test.go template for templ rendering tests
+9. [#321](https://github.com/anomalousventures/tracks/issues/321) - Create integration test template for full page rendering
+10. [#322](https://github.com/anomalousventures/tracks/issues/322) - Document handler-to-template integration in generated README
 
 ### Phase 3: Component Pattern Templates (Tasks 21-30)
 
-1. Create nav.templ component template
-2. Create footer.templ component template
-3. Create flash message component template
-4. Create breadcrumb component template
-5. Create card component template
-6. Create form input component template
-7. Create button component template
-8. Create modal component template
-9. Create component props pattern documentation template
-10. Create component composition examples in generated README
+1. [#323](https://github.com/anomalousventures/tracks/issues/323) - Create nav.templ component template
+2. [#324](https://github.com/anomalousventures/tracks/issues/324) - Create footer.templ component template
+3. [#325](https://github.com/anomalousventures/tracks/issues/325) - Create flash message component template
+4. [#326](https://github.com/anomalousventures/tracks/issues/326) - Create breadcrumb component template
+5. [#327](https://github.com/anomalousventures/tracks/issues/327) - Create card component template
+6. [#328](https://github.com/anomalousventures/tracks/issues/328) - Create form input component template
+7. [#329](https://github.com/anomalousventures/tracks/issues/329) - Create button component template
+8. [#330](https://github.com/anomalousventures/tracks/issues/330) - Create modal component template
+9. [#331](https://github.com/anomalousventures/tracks/issues/331) - Create component props pattern documentation template
+10. [#332](https://github.com/anomalousventures/tracks/issues/332) - Create component composition examples in generated README
 
 ### Phase 4: Advanced Pattern Templates (Tasks 31-40)
 
-1. Create HTMX attribute helper templates
-2. Create dark mode toggle component template
-3. Create layout with sidebar template
-4. Create partial rendering pattern template
-5. Create form validation display template
-6. Create list page pattern template
-7. Create detail page pattern template
-8. Create template error handling pattern
-9. Create template performance documentation
-10. Create templ troubleshooting guide template
+1. [#333](https://github.com/anomalousventures/tracks/issues/333) - Create HTMX attribute helper templates
+2. [#334](https://github.com/anomalousventures/tracks/issues/334) - Create dark mode toggle component template
+3. [#335](https://github.com/anomalousventures/tracks/issues/335) - Create layout with sidebar template
+4. [#336](https://github.com/anomalousventures/tracks/issues/336) - Create partial rendering pattern template
+5. [#337](https://github.com/anomalousventures/tracks/issues/337) - Create form validation display template
+6. [#338](https://github.com/anomalousventures/tracks/issues/338) - Create list page pattern template
+7. [#339](https://github.com/anomalousventures/tracks/issues/339) - Create detail page pattern template
+8. [#340](https://github.com/anomalousventures/tracks/issues/340) - Create template error handling pattern
+9. [#341](https://github.com/anomalousventures/tracks/issues/341) - Create template performance documentation
+10. [#342](https://github.com/anomalousventures/tracks/issues/342) - Create templ troubleshooting guide template
 
 ### Phase 5: ProjectGenerator Integration & Testing (Tasks 41-50)
 
-1. Wire view directory structure into ProjectGenerator
-2. Wire all .templ templates into ProjectGenerator
-3. Wire helpers.go template into ProjectGenerator
-4. Wire handler templates into ProjectGenerator
-5. Update go.mod template rendering to include templ
-6. Update Makefile template rendering for templ targets
-7. Test generated templates compile with `go tool templ generate`
-8. Test generated handlers render templates correctly
-9. Integration test: verify generated project's template tests pass
-10. Integration test: verify generated pages render in browser
+1. [#343](https://github.com/anomalousventures/tracks/issues/343) - Wire view directory structure into ProjectGenerator
+2. [#344](https://github.com/anomalousventures/tracks/issues/344) - Wire all .templ templates into ProjectGenerator
+3. [#345](https://github.com/anomalousventures/tracks/issues/345) - Wire helpers.go template into ProjectGenerator
+4. [#346](https://github.com/anomalousventures/tracks/issues/346) - Wire handler templates into ProjectGenerator
+5. [#347](https://github.com/anomalousventures/tracks/issues/347) - Update go.mod template rendering to include templ
+6. [#348](https://github.com/anomalousventures/tracks/issues/348) - Update Makefile template rendering for templ targets
+7. [#349](https://github.com/anomalousventures/tracks/issues/349) - Test generated templates compile with `go tool templ generate`
+8. [#350](https://github.com/anomalousventures/tracks/issues/350) - Test generated handlers render templates correctly
+9. [#351](https://github.com/anomalousventures/tracks/issues/351) - Integration test: verify generated project's template tests pass
+10. [#352](https://github.com/anomalousventures/tracks/issues/352) - Integration test: verify generated pages render via HTTP (using httptest, not browser)
 
 ## Dependencies
 


### PR DESCRIPTION
## What

Mark Epic 1.1 (Chi Router Setup) as complete and prepare Epic 1.2 (Templ Templates) with GitHub issue links.

## Why

Epic 1.1 has been completed with all 35 tasks closed in milestone v0.3.0. Epic 1.2 is ready to begin implementation with all 50 tasks created as GitHub issues.

This PR:
- Adds completion status to Epic 1.1 documentation
- Links to closed milestone for Epic 1.1
- Corrects 6 task descriptions in Epic 1.2 for clarity
- Adds GitHub issue numbers (#303-#352) to all 50 Epic 1.2 tasks

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

All 50 Epic 1.2 issues have been created in milestone v0.3.0 (same as Epic 1.1):
- Phase 1 (View Structure): #303-#312
- Phase 2 (Handler Integration): #313-#322
- Phase 3 (Component Patterns): #323-#332
- Phase 4 (Advanced Patterns): #333-#342
- Phase 5 (Generator Integration & Testing): #343-#352