### PR TITLE
refactor: remove WHAT comment from SafeHTML

### DIFF
--- a/internal/templates/project/internal/http/views/helpers.go.tmpl
+++ b/internal/templates/project/internal/http/views/helpers.go.tmpl
@@ -22,8 +22,6 @@ func ToggleClass(condition bool, activeClass, inactiveClass string) string {
 	return inactiveClass
 }
 
-// SafeHTML marks a string as safe HTML that should not be escaped by templ.
-//
 // ⚠️ SECURITY WARNING: This function disables HTML escaping. Only use with
 // trusted, sanitized HTML. Using this with user input creates XSS vulnerabilities.
 // In most cases, you should NOT use this function - templ's default escaping is safer.


### PR DESCRIPTION
## What

Remove WHAT comment from SafeHTML helper.

## Why

Follow project comment policy.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

Follow-up to #354.