### PR TITLE
feat: create meta.templ component template (issue #312)

### DIFF
--- a/internal/templates/project/internal/http/views/components/meta.templ.tmpl
+++ b/internal/templates/project/internal/http/views/components/meta.templ.tmpl
@@ -1,0 +1,8 @@
+package components
+
+templ Meta(title, description string) {
+	<title>{ title } - Tracks</title>
+	<meta name="description" content={ description }/>
+	<meta property="og:title" content={ title }/>
+	<meta property="og:description" content={ description }/>
+}


### PR DESCRIPTION
## What

Create reusable Meta component template for HTML meta tags.

## Why

Provides SEO and social sharing meta tags in a composable component format:
- Page title with "- Tracks" suffix
- Description meta tag for search engines
- Open Graph title/description for social sharing

Component accepts title and description as parameters, keeping meta tag management DRY.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)
- [x] Integration tests verify generated code compiles

## Notes

Closes #312

Component created in new `components/` directory following existing template patterns. Future task will update base.templ to use `@components.Meta()` instead of hardcoded meta tags.