### PR TITLE
chore: remove file path filters from claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,14 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Makefile'
-      - '**/*.md'
-      - '**/*.mdx'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## What

Removes the `paths` filter from the Claude Code Review workflow so it runs on ALL pull requests regardless of which files are changed.

## Why

Previously, the workflow only triggered when specific file types changed (`.go`, `.md`, `.mdx`, `Makefile`, `go.mod`, `go.sum`). This excluded important files like:
- `.go.tmpl` template files (the majority of our codebase)
- `.yml` workflow files
- Configuration files
- Other file types that benefit from code review

This change ensures consistent code review coverage across the entire codebase.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

The workflow will now run on every PR, which provides better coverage but uses more CI minutes. The concurrency settings already prevent multiple runs from overlapping for the same PR.