### PR TITLE
fix: allow claude bot in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Allow claude bot to trigger workflow
+          allowed_bots: 'claude'
+
           # Enable progress tracking for visual feedback
           track_progress: true
 


### PR DESCRIPTION
## What

Adds `allowed_bots: 'claude'` to the Claude Code Review workflow configuration.

## Why

The workflow was failing when triggered by the claude bot with error:
```
Workflow initiated by non-human actor: claude (type: Bot). 
Add bot to allowed_bots list or use '*' to allow all bots.
```

This prevents the claude bot from triggering code reviews on its own PRs.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

This is a workflow configuration change only. The fix will be validated when the next claude bot PR triggers the review workflow.