### PR TITLE
feat: add component test templates with goquery assertions

### DIFF
--- a/internal/templates/project/internal/http/views/components/counter_test.go.tmpl
+++ b/internal/templates/project/internal/http/views/components/counter_test.go.tmpl
@@ -1,0 +1,353 @@
+package components
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// For more information on accessible query testing patterns with goquery:
+// See: https://templ.guide/core-concepts/testing/
+
+func TestCounterPartial(t *testing.T) {
+	tests := []struct {
+		name       string
+		count      int
+		wantCount  string
+		assertions func(t *testing.T, doc *goquery.Document)
+	}{
+		{
+			name:      "should render counter with zero count",
+			count:     0,
+			wantCount: "0",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert counter display container
+				container := doc.Find("#counter-display")
+				assert.Equal(t, 1, container.Length(), "should have counter-display container")
+				assert.True(t, container.HasClass("counter-partial"), "container should have counter-partial class")
+
+				// Assert count display
+				countText := doc.Find("#counter-display p strong").Text()
+				assert.Equal(t, "0", countText, "should display count of 0")
+
+				// Assert increment button with HTMX attributes
+				incrementBtn := doc.Find("button").FilterFunction(func(i int, s *goquery.Selection) bool {
+					return s.Text() == "Increment"
+				})
+				assert.Equal(t, 1, incrementBtn.Length(), "should have increment button")
+
+				hxPost, exists := incrementBtn.Attr("hx-post")
+				assert.True(t, exists, "increment button should have hx-post attribute")
+				assert.Equal(t, "/examples/counter/increment", hxPost, "increment button should post to correct endpoint")
+
+				hxTarget, exists := incrementBtn.Attr("hx-target")
+				assert.True(t, exists, "increment button should have hx-target attribute")
+				assert.Equal(t, "#counter-display", hxTarget, "increment button should target counter-display")
+
+				hxSwap, exists := incrementBtn.Attr("hx-swap")
+				assert.True(t, exists, "increment button should have hx-swap attribute")
+				assert.Equal(t, "outerHTML", hxSwap, "increment button should use outerHTML swap")
+
+				// Assert decrement button with HTMX attributes
+				decrementBtn := doc.Find("button").FilterFunction(func(i int, s *goquery.Selection) bool {
+					return s.Text() == "Decrement"
+				})
+				assert.Equal(t, 1, decrementBtn.Length(), "should have decrement button")
+
+				hxPost, exists = decrementBtn.Attr("hx-post")
+				assert.True(t, exists, "decrement button should have hx-post attribute")
+				assert.Equal(t, "/examples/counter/decrement", hxPost, "decrement button should post to correct endpoint")
+
+				hxTarget, exists = decrementBtn.Attr("hx-target")
+				assert.True(t, exists, "decrement button should have hx-target attribute")
+				assert.Equal(t, "#counter-display", hxTarget, "decrement button should target counter-display")
+
+				hxSwap, exists = decrementBtn.Attr("hx-swap")
+				assert.True(t, exists, "decrement button should have hx-swap attribute")
+				assert.Equal(t, "outerHTML", hxSwap, "decrement button should use outerHTML swap")
+
+				// Assert reset button with HTMX attributes
+				resetBtn := doc.Find("button").FilterFunction(func(i int, s *goquery.Selection) bool {
+					return s.Text() == "Reset"
+				})
+				assert.Equal(t, 1, resetBtn.Length(), "should have reset button")
+
+				hxPost, exists = resetBtn.Attr("hx-post")
+				assert.True(t, exists, "reset button should have hx-post attribute")
+				assert.Equal(t, "/examples/counter/reset", hxPost, "reset button should post to correct endpoint")
+
+				hxTarget, exists = resetBtn.Attr("hx-target")
+				assert.True(t, exists, "reset button should have hx-target attribute")
+				assert.Equal(t, "#counter-display", hxTarget, "reset button should target counter-display")
+
+				hxSwap, exists = resetBtn.Attr("hx-swap")
+				assert.True(t, exists, "reset button should have hx-swap attribute")
+				assert.Equal(t, "outerHTML", hxSwap, "reset button should use outerHTML swap")
+			},
+		},
+		{
+			name:      "should render counter with positive count",
+			count:     42,
+			wantCount: "42",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert count display
+				countText := doc.Find("#counter-display p strong").Text()
+				assert.Equal(t, "42", countText, "should display count of 42")
+
+				// Assert all three buttons exist
+				buttons := doc.Find("button")
+				assert.Equal(t, 3, buttons.Length(), "should have 3 buttons (increment, decrement, reset)")
+			},
+		},
+		{
+			name:      "should render counter with negative count",
+			count:     -10,
+			wantCount: "-10",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert count display
+				countText := doc.Find("#counter-display p strong").Text()
+				assert.Equal(t, "-10", countText, "should display count of -10")
+			},
+		},
+		{
+			name:      "should render counter with large count",
+			count:     999999,
+			wantCount: "999999",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert count display
+				countText := doc.Find("#counter-display p strong").Text()
+				assert.Equal(t, "999999", countText, "should display large count")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Render component to buffer
+			var buf bytes.Buffer
+			err := CounterPartial(tt.count).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			// Parse with goquery
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			// Run custom assertions
+			if tt.assertions != nil {
+				tt.assertions(t, doc)
+			}
+		})
+	}
+}
+
+func TestCounterPage(t *testing.T) {
+	tests := []struct {
+		name       string
+		count      int
+		assertions func(t *testing.T, doc *goquery.Document)
+	}{
+		{
+			name:  "should render full counter page",
+			count: 5,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert page heading
+				heading := doc.Find("h1")
+				assert.Equal(t, 1, heading.Length(), "should have h1 heading")
+				assert.Contains(t, heading.Text(), "HTMX Partial Rendering Example", "heading should contain correct text")
+
+				// Assert description paragraph with link
+				descPara := doc.Find("p").First()
+				assert.Contains(t, descPara.Text(), "This counter demonstrates HTMX partial rendering patterns", "should have description")
+
+				docLink := doc.Find("a[href='https://go-tracks.io/docs/htmx-patterns']")
+				assert.Equal(t, 1, docLink.Length(), "should have link to HTMX patterns guide")
+
+				// Assert counter partial is embedded
+				counterDisplay := doc.Find("#counter-display")
+				assert.Equal(t, 1, counterDisplay.Length(), "should have embedded counter display")
+
+				countText := doc.Find("#counter-display p strong").Text()
+				assert.Equal(t, "5", countText, "should display count of 5")
+
+				// Assert notification area for OOB swaps
+				notificationArea := doc.Find("#notification-area")
+				assert.Equal(t, 1, notificationArea.Length(), "should have notification area")
+
+				// Assert buttons with HTMX attributes exist
+				buttons := doc.Find("button")
+				assert.Equal(t, 3, buttons.Length(), "should have 3 buttons")
+			},
+		},
+		{
+			name:  "should render page with zero count",
+			count: 0,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert counter displays zero
+				countText := doc.Find("#counter-display p strong").Text()
+				assert.Equal(t, "0", countText, "should display count of 0")
+
+				// Assert all HTMX interactive elements are present
+				buttons := doc.Find("button[hx-post]")
+				assert.Equal(t, 3, buttons.Length(), "should have 3 HTMX-enabled buttons")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Render component to buffer
+			var buf bytes.Buffer
+			err := CounterPage(tt.count).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			// Parse with goquery
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			// Run custom assertions
+			if tt.assertions != nil {
+				tt.assertions(t, doc)
+			}
+		})
+	}
+}
+
+func TestNotificationOOB(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     string
+		messageType string
+		assertions  func(t *testing.T, doc *goquery.Document)
+	}{
+		{
+			name:        "should render success notification with OOB swap",
+			message:     "Counter incremented!",
+			messageType: "success",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert notification container
+				notification := doc.Find("#notification-area")
+				assert.Equal(t, 1, notification.Length(), "should have notification area")
+
+				// Assert HTMX OOB swap attribute
+				hxSwapOob, exists := notification.Attr("hx-swap-oob")
+				assert.True(t, exists, "notification should have hx-swap-oob attribute")
+				assert.Equal(t, "true", hxSwapOob, "hx-swap-oob should be true")
+
+				// Assert notification classes
+				assert.True(t, notification.HasClass("notification"), "should have notification class")
+				assert.True(t, notification.HasClass("success"), "should have success class")
+
+				// Assert message content
+				message := notification.Find("p").Text()
+				assert.Equal(t, "Counter incremented!", message, "should display correct message")
+			},
+		},
+		{
+			name:        "should render error notification with OOB swap",
+			message:     "An error occurred",
+			messageType: "error",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert notification container
+				notification := doc.Find("#notification-area")
+				assert.Equal(t, 1, notification.Length(), "should have notification area")
+
+				// Assert HTMX OOB swap attribute
+				hxSwapOob, exists := notification.Attr("hx-swap-oob")
+				assert.True(t, exists, "notification should have hx-swap-oob attribute")
+				assert.Equal(t, "true", hxSwapOob, "hx-swap-oob should be true")
+
+				// Assert notification classes
+				assert.True(t, notification.HasClass("notification"), "should have notification class")
+				assert.True(t, notification.HasClass("error"), "should have error class")
+
+				// Assert message content
+				message := notification.Find("p").Text()
+				assert.Equal(t, "An error occurred", message, "should display correct message")
+			},
+		},
+		{
+			name:        "should render info notification with OOB swap",
+			message:     "Counter reset to zero",
+			messageType: "info",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert notification container
+				notification := doc.Find("#notification-area")
+				assert.True(t, notification.HasClass("info"), "should have info class")
+
+				// Assert message content
+				message := notification.Find("p").Text()
+				assert.Equal(t, "Counter reset to zero", message, "should display correct message")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Render component to buffer
+			var buf bytes.Buffer
+			err := NotificationOOB(tt.message, tt.messageType).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			// Parse with goquery
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			// Run custom assertions
+			if tt.assertions != nil {
+				tt.assertions(t, doc)
+			}
+		})
+	}
+}
+
+func TestCounter_HTMXAttributeValidation(t *testing.T) {
+	// This test validates that all HTMX attributes are correctly set
+	// This is crucial for HTMX components to work properly
+
+	count := 0
+	var buf bytes.Buffer
+	err := CounterPartial(count).Render(context.Background(), &buf)
+	require.NoError(t, err, "component should render without error")
+
+	doc, err := goquery.NewDocumentFromReader(&buf)
+	require.NoError(t, err, "should parse rendered HTML")
+
+	// Define expected HTMX attributes for each button
+	expectedButtons := []struct {
+		text     string
+		hxPost   string
+		hxTarget string
+		hxSwap   string
+	}{
+		{"Increment", "/examples/counter/increment", "#counter-display", "outerHTML"},
+		{"Decrement", "/examples/counter/decrement", "#counter-display", "outerHTML"},
+		{"Reset", "/examples/counter/reset", "#counter-display", "outerHTML"},
+	}
+
+	for _, expected := range expectedButtons {
+		t.Run("validate HTMX attributes for "+expected.text+" button", func(t *testing.T) {
+			button := doc.Find("button").FilterFunction(func(i int, s *goquery.Selection) bool {
+				return s.Text() == expected.text
+			})
+
+			require.Equal(t, 1, button.Length(), "should find %s button", expected.text)
+
+			// Validate all HTMX attributes
+			hxPost, exists := button.Attr("hx-post")
+			assert.True(t, exists, "%s button must have hx-post attribute", expected.text)
+			assert.Equal(t, expected.hxPost, hxPost, "%s button hx-post should match", expected.text)
+
+			hxTarget, exists := button.Attr("hx-target")
+			assert.True(t, exists, "%s button must have hx-target attribute", expected.text)
+			assert.Equal(t, expected.hxTarget, hxTarget, "%s button hx-target should match", expected.text)
+
+			hxSwap, exists := button.Attr("hx-swap")
+			assert.True(t, exists, "%s button must have hx-swap attribute", expected.text)
+			assert.Equal(t, expected.hxSwap, hxSwap, "%s button hx-swap should match", expected.text)
+		})
+	}
+}

--- a/internal/templates/project/internal/http/views/components/footer_test.go.tmpl
+++ b/internal/templates/project/internal/http/views/components/footer_test.go.tmpl
@@ -1,0 +1,288 @@
+package components
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// For more information on accessible query testing patterns with goquery:
+// See: https://templ.guide/core-concepts/testing/
+
+func TestFooter(t *testing.T) {
+	tests := []struct {
+		name              string
+		props             FooterProps
+		wantCopyright     string
+		wantLinksCount    int
+		wantTracksCredit  bool
+		wantFooterNavAria bool
+		assertions        func(t *testing.T, doc *goquery.Document)
+	}{
+		{
+			name: "should render footer with copyright, links, and Tracks credit",
+			props: FooterProps{
+				Year:        2024,
+				ProjectName: "MyApp",
+				Links: []FooterLink{
+					{Text: "Privacy Policy", URL: "/privacy"},
+					{Text: "Terms of Service", URL: "/terms"},
+					{Text: "Contact", URL: "/contact"},
+				},
+				ShowTracksCredit: true,
+			},
+			wantCopyright:     "© 2024 MyApp. All rights reserved.",
+			wantLinksCount:    3,
+			wantTracksCredit:  true,
+			wantFooterNavAria: true,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert footer element exists
+				footer := doc.Find("footer")
+				assert.Equal(t, 1, footer.Length(), "should have exactly one footer element")
+
+				// Assert copyright text
+				copyright := doc.Find("footer small").First()
+				assert.Contains(t, copyright.Text(), "© 2024 MyApp. All rights reserved.", "should contain copyright text")
+
+				// Assert footer navigation with aria-label
+				footerNav := doc.Find("footer nav[aria-label='Footer navigation']")
+				assert.Equal(t, 1, footerNav.Length(), "should have footer navigation with aria-label")
+
+				// Assert footer links
+				footerLinks := doc.Find("footer nav a")
+				assert.Equal(t, 3, footerLinks.Length(), "should have 3 footer links")
+
+				// Assert Privacy Policy link
+				privacyLink := doc.Find("footer nav a:contains('Privacy Policy')")
+				assert.Equal(t, 1, privacyLink.Length(), "should have Privacy Policy link")
+				href, exists := privacyLink.Attr("href")
+				assert.True(t, exists, "Privacy Policy link should have href")
+				assert.Equal(t, "/privacy", href, "Privacy Policy link should point to /privacy")
+
+				// Assert Terms of Service link
+				termsLink := doc.Find("footer nav a:contains('Terms of Service')")
+				assert.Equal(t, 1, termsLink.Length(), "should have Terms of Service link")
+				href, exists = termsLink.Attr("href")
+				assert.True(t, exists, "Terms of Service link should have href")
+				assert.Equal(t, "/terms", href, "Terms of Service link should point to /terms")
+
+				// Assert Contact link
+				contactLink := doc.Find("footer nav a:contains('Contact')")
+				assert.Equal(t, 1, contactLink.Length(), "should have Contact link")
+				href, exists = contactLink.Attr("href")
+				assert.True(t, exists, "Contact link should have href")
+				assert.Equal(t, "/contact", href, "Contact link should point to /contact")
+
+				// Assert Tracks credit
+				tracksCredit := doc.Find("footer a[href='https://go-tracks.io']")
+				assert.Equal(t, 1, tracksCredit.Length(), "should have Tracks credit link")
+				assert.Contains(t, tracksCredit.Text(), "Tracks", "Tracks credit should contain 'Tracks' text")
+
+				// Assert Tracks link has security attributes
+				target, exists := tracksCredit.Attr("target")
+				assert.True(t, exists, "Tracks link should have target attribute")
+				assert.Equal(t, "_blank", target, "Tracks link should open in new tab")
+
+				rel, exists := tracksCredit.Attr("rel")
+				assert.True(t, exists, "Tracks link should have rel attribute")
+				assert.Contains(t, rel, "noopener", "Tracks link should have noopener")
+				assert.Contains(t, rel, "noreferrer", "Tracks link should have noreferrer")
+			},
+		},
+		{
+			name: "should render footer without links",
+			props: FooterProps{
+				Year:             2024,
+				ProjectName:      "MyApp",
+				Links:            []FooterLink{},
+				ShowTracksCredit: false,
+			},
+			wantCopyright:     "© 2024 MyApp. All rights reserved.",
+			wantLinksCount:    0,
+			wantTracksCredit:  false,
+			wantFooterNavAria: false,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert copyright exists
+				copyright := doc.Find("footer small").First()
+				assert.Contains(t, copyright.Text(), "© 2024 MyApp. All rights reserved.", "should contain copyright text")
+
+				// Assert no footer navigation
+				footerNav := doc.Find("footer nav")
+				assert.Equal(t, 0, footerNav.Length(), "should not have footer navigation when no links")
+
+				// Assert no Tracks credit
+				tracksCredit := doc.Find("footer a[href='https://go-tracks.io']")
+				assert.Equal(t, 0, tracksCredit.Length(), "should not have Tracks credit when ShowTracksCredit is false")
+			},
+		},
+		{
+			name: "should render footer with only Tracks credit",
+			props: FooterProps{
+				Year:             2024,
+				ProjectName:      "MyApp",
+				Links:            []FooterLink{},
+				ShowTracksCredit: true,
+			},
+			wantCopyright:    "© 2024 MyApp. All rights reserved.",
+			wantLinksCount:   0,
+			wantTracksCredit: true,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert copyright exists
+				copyright := doc.Find("footer small").First()
+				assert.Contains(t, copyright.Text(), "© 2024 MyApp. All rights reserved.", "should contain copyright text")
+
+				// Assert Tracks credit exists
+				tracksCredit := doc.Find("footer a[href='https://go-tracks.io']")
+				assert.Equal(t, 1, tracksCredit.Length(), "should have Tracks credit")
+			},
+		},
+		{
+			name: "should render footer with single link",
+			props: FooterProps{
+				Year:        2024,
+				ProjectName: "MyApp",
+				Links: []FooterLink{
+					{Text: "Privacy Policy", URL: "/privacy"},
+				},
+				ShowTracksCredit: false,
+			},
+			wantCopyright:     "© 2024 MyApp. All rights reserved.",
+			wantLinksCount:    1,
+			wantTracksCredit:  false,
+			wantFooterNavAria: true,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert footer navigation exists even with single link
+				footerNav := doc.Find("footer nav[aria-label='Footer navigation']")
+				assert.Equal(t, 1, footerNav.Length(), "should have footer navigation with single link")
+
+				// Assert single link
+				footerLinks := doc.Find("footer nav a")
+				assert.Equal(t, 1, footerLinks.Length(), "should have 1 footer link")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Render component to buffer
+			var buf bytes.Buffer
+			err := Footer(tt.props).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			// Parse with goquery
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			// Run custom assertions
+			if tt.assertions != nil {
+				tt.assertions(t, doc)
+			}
+		})
+	}
+}
+
+func TestFooter_YearFormatting(t *testing.T) {
+	tests := []struct {
+		name     string
+		year     int
+		wantText string
+	}{
+		{
+			name:     "should format current year",
+			year:     2024,
+			wantText: "© 2024",
+		},
+		{
+			name:     "should format past year",
+			year:     2020,
+			wantText: "© 2020",
+		},
+		{
+			name:     "should format future year",
+			year:     2030,
+			wantText: "© 2030",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			props := FooterProps{
+				Year:             tt.year,
+				ProjectName:      "MyApp",
+				Links:            []FooterLink{},
+				ShowTracksCredit: false,
+			}
+
+			var buf bytes.Buffer
+			err := Footer(props).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			copyright := doc.Find("footer small").First()
+			assert.Contains(t, copyright.Text(), tt.wantText, "should contain formatted year")
+		})
+	}
+}
+
+func TestFooter_LinkSafety(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		wantRendered bool
+	}{
+		{
+			name:         "should render safe internal URLs",
+			url:          "/privacy",
+			wantRendered: true,
+		},
+		{
+			name:         "should render safe external URLs",
+			url:          "https://example.com",
+			wantRendered: true,
+		},
+		{
+			name: "should sanitize javascript: URLs",
+			url:  "javascript:alert('xss')",
+			// templ.URL should strip unsafe URLs
+			wantRendered: true, // Will render but sanitized
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			props := FooterProps{
+				Year:        2024,
+				ProjectName: "MyApp",
+				Links: []FooterLink{
+					{Text: "Test Link", URL: tt.url},
+				},
+				ShowTracksCredit: false,
+			}
+
+			var buf bytes.Buffer
+			err := Footer(props).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			testLink := doc.Find("footer nav a:contains('Test Link')")
+			if tt.wantRendered {
+				assert.Equal(t, 1, testLink.Length(), "link should be rendered")
+				href, exists := testLink.Attr("href")
+				assert.True(t, exists, "link should have href attribute")
+
+				// For javascript: URLs, templ.URL should sanitize them
+				if tt.url == "javascript:alert('xss')" {
+					assert.NotContains(t, href, "javascript:", "javascript: URLs should be sanitized")
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/project/internal/http/views/components/meta_test.go.tmpl
+++ b/internal/templates/project/internal/http/views/components/meta_test.go.tmpl
@@ -1,0 +1,232 @@
+package components
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// For more information on accessible query testing patterns with goquery:
+// See: https://templ.guide/core-concepts/testing/
+
+func TestMeta(t *testing.T) {
+	tests := []struct {
+		name            string
+		title           string
+		description     string
+		wantTitle       string
+		wantDescription string
+		wantOGTitle     string
+		wantOGDesc      string
+		assertions      func(t *testing.T, doc *goquery.Document)
+	}{
+		{
+			name:            "should render meta tags with title and description",
+			title:           "Home",
+			description:     "Welcome to our application",
+			wantTitle:       "Home - Tracks",
+			wantDescription: "Welcome to our application",
+			wantOGTitle:     "Home",
+			wantOGDesc:      "Welcome to our application",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert title tag
+				title := doc.Find("title")
+				assert.Equal(t, 1, title.Length(), "should have exactly one title tag")
+				assert.Equal(t, "Home - Tracks", title.Text(), "title should match")
+
+				// Assert description meta tag
+				descMeta := doc.Find("meta[name='description']")
+				assert.Equal(t, 1, descMeta.Length(), "should have description meta tag")
+				content, exists := descMeta.Attr("content")
+				assert.True(t, exists, "description meta should have content attribute")
+				assert.Equal(t, "Welcome to our application", content, "description content should match")
+
+				// Assert Open Graph title
+				ogTitle := doc.Find("meta[property='og:title']")
+				assert.Equal(t, 1, ogTitle.Length(), "should have og:title meta tag")
+				content, exists = ogTitle.Attr("content")
+				assert.True(t, exists, "og:title should have content attribute")
+				assert.Equal(t, "Home", content, "og:title content should match")
+
+				// Assert Open Graph description
+				ogDesc := doc.Find("meta[property='og:description']")
+				assert.Equal(t, 1, ogDesc.Length(), "should have og:description meta tag")
+				content, exists = ogDesc.Attr("content")
+				assert.True(t, exists, "og:description should have content attribute")
+				assert.Equal(t, "Welcome to our application", content, "og:description content should match")
+			},
+		},
+		{
+			name:            "should render meta tags with empty title",
+			title:           "",
+			description:     "Default description",
+			wantTitle:       " - Tracks",
+			wantDescription: "Default description",
+			wantOGTitle:     "",
+			wantOGDesc:      "Default description",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert title tag with empty title still renders suffix
+				title := doc.Find("title")
+				assert.Equal(t, 1, title.Length(), "should have title tag")
+				assert.Equal(t, " - Tracks", title.Text(), "title should render with suffix only")
+
+				// Assert description still renders
+				descMeta := doc.Find("meta[name='description']")
+				assert.Equal(t, 1, descMeta.Length(), "should have description meta tag")
+				content, exists := descMeta.Attr("content")
+				assert.True(t, exists, "description should have content")
+				assert.Equal(t, "Default description", content, "description should match")
+			},
+		},
+		{
+			name:            "should render meta tags with empty description",
+			title:           "Home",
+			description:     "",
+			wantTitle:       "Home - Tracks",
+			wantDescription: "",
+			wantOGTitle:     "Home",
+			wantOGDesc:      "",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert title renders correctly
+				title := doc.Find("title")
+				assert.Equal(t, 1, title.Length(), "should have title tag")
+				assert.Equal(t, "Home - Tracks", title.Text(), "title should render correctly")
+
+				// Assert description meta tag exists with empty content
+				descMeta := doc.Find("meta[name='description']")
+				assert.Equal(t, 1, descMeta.Length(), "should have description meta tag")
+				content, exists := descMeta.Attr("content")
+				assert.True(t, exists, "description should have content attribute")
+				assert.Equal(t, "", content, "description content should be empty")
+			},
+		},
+		{
+			name:            "should handle special characters in title",
+			title:           "Home & About",
+			description:     "Learn about <our> application",
+			wantTitle:       "Home & About - Tracks",
+			wantDescription: "Learn about <our> application",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert title properly escapes special characters
+				title := doc.Find("title")
+				assert.Equal(t, "Home & About - Tracks", title.Text(), "title should properly handle special characters")
+
+				// Assert description properly escapes special characters
+				descMeta := doc.Find("meta[name='description']")
+				content, exists := descMeta.Attr("content")
+				assert.True(t, exists, "description should have content")
+				assert.Equal(t, "Learn about <our> application", content, "description should properly handle special characters")
+			},
+		},
+		{
+			name:        "should render long title and description",
+			title:       "This is a very long title that might be used for SEO purposes and should still render correctly",
+			description: "This is a very long description that provides detailed information about the page content and might be used for search engine optimization and social media sharing purposes",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert long title renders
+				title := doc.Find("title")
+				assert.Equal(t, 1, title.Length(), "should have title tag")
+				assert.Contains(t, title.Text(), "This is a very long title", "should contain full title")
+
+				// Assert long description renders
+				descMeta := doc.Find("meta[name='description']")
+				content, exists := descMeta.Attr("content")
+				assert.True(t, exists, "description should have content")
+				assert.Contains(t, content, "very long description", "should contain full description")
+			},
+		},
+		{
+			name:        "should render meta tags with unicode characters",
+			title:       "Welcome 欢迎 🎉",
+			description: "International support: English, 中文, Español, العربية",
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert title with unicode
+				title := doc.Find("title")
+				assert.Contains(t, title.Text(), "欢迎", "should render unicode characters in title")
+				assert.Contains(t, title.Text(), "🎉", "should render emoji in title")
+
+				// Assert description with unicode
+				descMeta := doc.Find("meta[name='description']")
+				content, exists := descMeta.Attr("content")
+				assert.True(t, exists, "description should have content")
+				assert.Contains(t, content, "中文", "should render unicode characters in description")
+				assert.Contains(t, content, "العربية", "should render RTL unicode in description")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Render component to buffer
+			var buf bytes.Buffer
+			err := Meta(tt.title, tt.description).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			// Wrap in html/head for goquery parsing
+			htmlDoc := "<html><head>" + buf.String() + "</head></html>"
+			doc, err := goquery.NewDocumentFromReader(bytes.NewBufferString(htmlDoc))
+			require.NoError(t, err, "should parse rendered HTML")
+
+			// Run custom assertions
+			if tt.assertions != nil {
+				tt.assertions(t, doc)
+			}
+		})
+	}
+}
+
+func TestMeta_AllTagsPresent(t *testing.T) {
+	title := "Test Page"
+	description := "Test description"
+
+	var buf bytes.Buffer
+	err := Meta(title, description).Render(context.Background(), &buf)
+	require.NoError(t, err, "component should render without error")
+
+	// Wrap in html/head for goquery parsing
+	htmlDoc := "<html><head>" + buf.String() + "</head></html>"
+	doc, err := goquery.NewDocumentFromReader(bytes.NewBufferString(htmlDoc))
+	require.NoError(t, err, "should parse rendered HTML")
+
+	// Assert all expected meta tags are present
+	requiredTags := []struct {
+		selector string
+		tagType  string
+	}{
+		{"title", "title element"},
+		{"meta[name='description']", "description meta tag"},
+		{"meta[property='og:title']", "Open Graph title"},
+		{"meta[property='og:description']", "Open Graph description"},
+	}
+
+	for _, tag := range requiredTags {
+		elements := doc.Find(tag.selector)
+		assert.Equal(t, 1, elements.Length(), "should have exactly one %s", tag.tagType)
+	}
+}
+
+func TestMeta_NoExtraMetaTags(t *testing.T) {
+	title := "Test Page"
+	description := "Test description"
+
+	var buf bytes.Buffer
+	err := Meta(title, description).Render(context.Background(), &buf)
+	require.NoError(t, err, "component should render without error")
+
+	// Wrap in html/head for goquery parsing
+	htmlDoc := "<html><head>" + buf.String() + "</head></html>"
+	doc, err := goquery.NewDocumentFromReader(bytes.NewBufferString(htmlDoc))
+	require.NoError(t, err, "should parse rendered HTML")
+
+	// Assert only expected meta tags are present (2 OG tags + 1 description)
+	metaTags := doc.Find("meta")
+	assert.Equal(t, 3, metaTags.Length(), "should have exactly 3 meta tags")
+
+	// Assert title tag
+	titleTags := doc.Find("title")
+	assert.Equal(t, 1, titleTags.Length(), "should have exactly 1 title tag")
+}

--- a/internal/templates/project/internal/http/views/components/nav_test.go.tmpl
+++ b/internal/templates/project/internal/http/views/components/nav_test.go.tmpl
@@ -1,0 +1,218 @@
+package components
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"{{.ModuleName}}/internal/http/routes"
+)
+
+// For more information on accessible query testing patterns with goquery:
+// See: https://templ.guide/core-concepts/testing/
+
+func TestNav(t *testing.T) {
+	tests := []struct {
+		name           string
+		props          NavProps
+		wantLogo       bool
+		wantLogoText   string
+		wantLogoHref   string
+		wantLinksCount int
+		wantMobileNav  bool
+		assertions     func(t *testing.T, doc *goquery.Document)
+	}{
+		{
+			name: "should render navigation with logo and links",
+			props: NavProps{
+				Logo: "MyApp",
+				Links: []NavLink{
+					{Label: "Home", Href: routes.Home, Active: true},
+					{Label: "About", Href: routes.About, Active: false},
+				},
+				MobileNav: true,
+			},
+			wantLogo:       true,
+			wantLogoText:   "MyApp",
+			wantLogoHref:   routes.Home,
+			wantLinksCount: 2,
+			wantMobileNav:  true,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert navigation wrapper exists
+				nav := doc.Find("nav")
+				assert.Equal(t, 1, nav.Length(), "should have exactly one nav element")
+
+				// Assert logo exists and has correct properties
+				logo := doc.Find("nav a").First()
+				assert.Equal(t, "MyApp", logo.Text(), "logo text should match")
+				href, exists := logo.Attr("href")
+				assert.True(t, exists, "logo should have href attribute")
+				assert.Equal(t, routes.Home, href, "logo href should point to home")
+
+				// Assert navigation links
+				navLinks := doc.Find("nav a").Slice(1, 100) // All links except logo
+				assert.Equal(t, 2, navLinks.Length(), "should have 2 navigation links")
+
+				// Assert active link has aria-current
+				homeLink := doc.Find("nav a:contains('Home')").Last()
+				ariaCurrent, exists := homeLink.Attr("aria-current")
+				assert.True(t, exists, "active link should have aria-current attribute")
+				assert.Equal(t, "page", ariaCurrent, "active link should have aria-current='page'")
+
+				// Assert inactive link does not have aria-current
+				aboutLink := doc.Find("nav a:contains('About')")
+				_, exists = aboutLink.Attr("aria-current")
+				assert.False(t, exists, "inactive link should not have aria-current attribute")
+
+				// Assert mobile nav button
+				mobileButton := doc.Find("button[aria-label='Toggle navigation menu']")
+				assert.Equal(t, 1, mobileButton.Length(), "should have mobile nav button")
+				ariaExpanded, exists := mobileButton.Attr("aria-expanded")
+				assert.True(t, exists, "mobile button should have aria-expanded attribute")
+				assert.Equal(t, "false", ariaExpanded, "mobile button aria-expanded should be false")
+			},
+		},
+		{
+			name: "should render navigation without logo",
+			props: NavProps{
+				Logo: "",
+				Links: []NavLink{
+					{Label: "Home", Href: routes.Home, Active: false},
+				},
+				MobileNav: false,
+			},
+			wantLogo:       false,
+			wantLinksCount: 1,
+			wantMobileNav:  false,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert no logo link with brand text
+				logoLinks := doc.Find("nav div.flex-shrink-0 a")
+				assert.Equal(t, 0, logoLinks.Length(), "should not render logo when empty")
+
+				// Assert navigation links still render
+				navLinks := doc.Find("nav a")
+				assert.Equal(t, 1, navLinks.Length(), "should have 1 navigation link")
+
+				// Assert no mobile nav button
+				mobileButton := doc.Find("button[aria-label='Toggle navigation menu']")
+				assert.Equal(t, 0, mobileButton.Length(), "should not have mobile nav button")
+			},
+		},
+		{
+			name: "should render navigation with no links",
+			props: NavProps{
+				Logo:      "MyApp",
+				Links:     []NavLink{},
+				MobileNav: false,
+			},
+			wantLogo:       true,
+			wantLogoText:   "MyApp",
+			wantLinksCount: 0,
+			wantMobileNav:  false,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert logo exists
+				logo := doc.Find("nav a").First()
+				assert.Equal(t, "MyApp", logo.Text(), "logo should still render")
+
+				// Assert no navigation links (only logo link)
+				allLinks := doc.Find("nav a")
+				assert.Equal(t, 1, allLinks.Length(), "should only have logo link")
+			},
+		},
+		{
+			name: "should handle multiple active links",
+			props: NavProps{
+				Logo: "MyApp",
+				Links: []NavLink{
+					{Label: "Home", Href: routes.Home, Active: true},
+					{Label: "About", Href: routes.About, Active: true},
+				},
+				MobileNav: false,
+			},
+			wantLogo:       true,
+			wantLinksCount: 2,
+			assertions: func(t *testing.T, doc *goquery.Document) {
+				// Assert both links have aria-current (even though typically only one should be active)
+				activeLinks := doc.Find("nav a[aria-current='page']")
+				assert.Equal(t, 2, activeLinks.Length(), "both links should have aria-current when marked active")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Render component to buffer
+			var buf bytes.Buffer
+			err := Nav(tt.props).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			// Parse with goquery
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			// Run custom assertions
+			if tt.assertions != nil {
+				tt.assertions(t, doc)
+			}
+		})
+	}
+}
+
+func TestNav_HrefSafety(t *testing.T) {
+	tests := []struct {
+		name         string
+		href         string
+		wantRendered bool
+	}{
+		{
+			name:         "should render safe internal URLs",
+			href:         "/about",
+			wantRendered: true,
+		},
+		{
+			name:         "should render safe external URLs",
+			href:         "https://example.com",
+			wantRendered: true,
+		},
+		{
+			name: "should sanitize javascript: URLs",
+			href: "javascript:alert('xss')",
+			// templ.SafeURL should strip unsafe URLs
+			wantRendered: true, // Will render but sanitized
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			props := NavProps{
+				Logo: "MyApp",
+				Links: []NavLink{
+					{Label: "Test", Href: tt.href, Active: false},
+				},
+			}
+
+			var buf bytes.Buffer
+			err := Nav(props).Render(context.Background(), &buf)
+			require.NoError(t, err, "component should render without error")
+
+			doc, err := goquery.NewDocumentFromReader(&buf)
+			require.NoError(t, err, "should parse rendered HTML")
+
+			testLink := doc.Find("nav a:contains('Test')")
+			if tt.wantRendered {
+				assert.Equal(t, 1, testLink.Length(), "link should be rendered")
+				href, exists := testLink.Attr("href")
+				assert.True(t, exists, "link should have href attribute")
+
+				// For javascript: URLs, templ.SafeURL should sanitize them
+				if tt.href == "javascript:alert('xss')" {
+					assert.NotContains(t, href, "javascript:", "javascript: URLs should be sanitized")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Create test templates for templ components (nav, footer, meta, counter) with comprehensive goquery assertions for accessible testing patterns.

## Why

Closes #374

Part of Epic 1.2: Templ Templates - Provides testing examples for component-level tests using goquery accessible queries, demonstrating best practices for testing templ components including HTMX patterns.

## Changes

- Created `nav_test.go.tmpl` with ARIA validation and URL safety tests
- Created `footer_test.go.tmpl` with link security and copyright tests
- Created `meta_test.go.tmpl` with meta tag and Open Graph validation
- Created `counter_test.go.tmpl` with HTMX attribute testing patterns
- All tests use table-driven patterns for multiple scenarios
- All tests include documentation link to templ testing guide

## Testing

- ✅ `make generate-mocks` - Success
- ✅ `make lint-go` - Success
- ✅ `make test` - All tests passed
- ✅ `make test-integration` - All integration tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)