### PR TITLE
feat: add make targets for working with generated test projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,9 @@ test-gen-app-test: ## Run tests in generated test project
 	@cd /tmp/testapp && $(MAKE) test
 
 test-gen-app-validate: ## Run full validation on test project (mocks, lint, test)
-	@$(MAKE) test-gen-app-mocks
-	@$(MAKE) test-gen-app-lint
-	@$(MAKE) test-gen-app-test
+	@$(MAKE) test-gen-app-mocks && \
+	$(MAKE) test-gen-app-lint && \
+	$(MAKE) test-gen-app-test
 	@echo "✅ Test app validation complete"
 
 test-gen-app-full: test-gen-app test-gen-app-validate ## Full workflow: generate, validate, clean


### PR DESCRIPTION
Add convenience targets for operating on generated test projects:
- test-gen-app-lint: Run lint in test project
- test-gen-app-mocks: Generate mocks in test project
- test-gen-app-test: Run tests in test project
- test-gen-app-validate: Run full validation (mocks, lint, test)
- test-gen-app-full: Generate + validate workflow

All targets check for test app existence and provide helpful error messages. All targets documented in `make help` output.

Fixes #383

🤖 Generated with [Claude Code](https://claude.ai/code)