### PR TITLE
docs: merge Epic 1.3 + 1.4 into unified asset pipeline

### DIFF
--- a/docs/roadmap/phases/1-core-web/epics/1.3-asset-pipeline.md
+++ b/docs/roadmap/phases/1-core-web/epics/1.3-asset-pipeline.md
@@ -98,26 +98,26 @@ The following tasks will become GitHub issues, ordered by dependency:
 
 **Goal:** Get static file serving working with basic directory structure
 
-1. Create web/ directory structure template
+1. [#386](https://github.com/anomalousventures/tracks/issues/386) Create web/ directory structure template
    - `web/css/`, `web/js/`, `web/images/`
    - `.gitkeep` files for empty directories
    - Basic placeholder files (empty app.css, app.js)
 
-2. Create basic assets.go template
+2. [#387](https://github.com/anomalousventures/tracks/issues/387) Create basic assets.go template
    - Simple `embed.FS` without hashfs initially
    - Basic file server handler
    - Serve from `/assets/*` route
 
-3. Create static file handler template
+3. [#389](https://github.com/anomalousventures/tracks/issues/389) Create static file handler template
    - Basic `http.FileServerFS` handler
    - Wire into routes.go
    - Test that static files are served
 
-4. Add basic MIME type handling
+4. [#390](https://github.com/anomalousventures/tracks/issues/390) Add basic MIME type handling
    - Proper Content-Type headers
    - Support for common asset types (css, js, images, fonts)
 
-5. Update .gitignore template
+5. [#391](https://github.com/anomalousventures/tracks/issues/391) Update .gitignore template
    - Ignore `node_modules/`
    - Ignore generated asset outputs (`internal/assets/dist/`)
    - Keep source assets (`web/`)


### PR DESCRIPTION
## What

Merges Epic 1.3 (HashFS Assets - 40 tasks) and Epic 1.4 (Web Build Pipeline - 35 tasks) into a single cohesive Epic 1.3: Asset Build & Serving Pipeline (62 tasks).

The unified epic organizes the work into 9 phases:
1. Basic Asset Infrastructure (5 tasks)
2. Build Pipeline Setup (8 tasks)
3. Add HTMX v2 + Extensions (7 tasks)
4. Content-Addressed Serving (6 tasks)
5. Production Optimization (4 tasks)
6. Caching Strategy (6 tasks)
7. Development Workflow (6 tasks)
8. ProjectGenerator Integration (13 tasks)
9. Testing & Validation (7 tasks)

## Why

The original separate epics created artificial boundaries that complicated the asset build and serving flow. Key improvements:

- **Removes 13 tasks** of duplicated effort between the two epics
- **Simplifies build process** - always minify (no dev/prod mode switching)
- **Single build path** - `make build` builds everything (assets then binary)
- **Removes sourcemaps** - minimal JS usage doesn't need debugging infrastructure
- **Unified design** - build and serve concerns addressed together incrementally

Design principles:
- Build time: `make assets` compiles CSS/JS (always minified)
- Compile time: `go build` embeds assets via `//go:embed`
- Run time: hashfs serves with ETag + Cache-Control headers

## Testing

- [x] Markdown linting passes (`make lint-md`)
- [x] Pre-commit hooks pass (generate-mocks, lint, test, test-integration)
- [x] Epic document structure is complete and well-organized

## Notes

This is a documentation-only change that restructures the roadmap. After approval, Phase 1 issues will be created and implementation will begin.

The epic delivers a complete asset pipeline: TailwindCSS + esbuild → hashfs → ETag/Cache-Control → single binary deployment.