### PR TITLE
feat: update .gitignore template for asset pipeline

### DIFF
--- a/internal/templates/project/.gitignore.tmpl
+++ b/internal/templates/project/.gitignore.tmpl
@@ -26,3 +26,7 @@ Thumbs.db
 tmp/
 .air/
 data/
+
+# Asset Pipeline
+node_modules/
+internal/assets/dist/

--- a/tests/integration/generator_test.go
+++ b/tests/integration/generator_test.go
@@ -174,6 +174,13 @@ func TestGenerateFullProject(t *testing.T) {
 			assert.NotContains(t, string(makefileContent), "dev-full:", "Makefile should not contain dev-full target")
 			assert.NotContains(t, string(makefileContent), "dev-full     - Start docker services and dev server", "Makefile help should not mention dev-full")
 
+			gitignorePath := filepath.Join(projectRoot, ".gitignore")
+			gitignoreContent, err := os.ReadFile(gitignorePath)
+			require.NoError(t, err, "should be able to read .gitignore")
+			assert.Contains(t, string(gitignoreContent), "node_modules/", ".gitignore should exclude node_modules")
+			assert.Contains(t, string(gitignoreContent), "internal/assets/dist/", ".gitignore should exclude generated asset outputs")
+			assert.NotContains(t, string(gitignoreContent), "web/", ".gitignore should NOT exclude web/ source directory")
+
 			dockerignorePath := filepath.Join(projectRoot, ".dockerignore")
 			dockerignoreContent, err := os.ReadFile(dockerignorePath)
 			require.NoError(t, err, "should be able to read .dockerignore")


### PR DESCRIPTION
## Summary

Updates the .gitignore template to properly ignore generated asset outputs while keeping source assets.

## Changes

- Add `node_modules/` to .gitignore for npm dependencies
- Add `internal/assets/dist/` to ignore generated asset outputs
- Keep `web/` source directory NOT ignored
- Add integration test assertions to verify .gitignore patterns

## Testing

- ✅ Unit tests pass
- ✅ Integration tests pass with new assertions
- ✅ Linting passes
- ✅ Generated projects have correct .gitignore patterns

Closes #391

🤖 Generated with [Claude Code](https://claude.ai/code)