### PR TITLE
feat: add hashfs content-addressed asset serving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,12 +97,13 @@ test-e2e-local: ## Test E2E workflow locally (mimics CI e2e-workflow job)
 	@cd /tmp && $(CURDIR)/bin/tracks new testapp-e2e --db=sqlite3 --module=github.com/test/app || true
 	@cd /tmp/testapp-e2e && make test
 	@echo "Starting dev server..."
-	@cd /tmp/testapp-e2e && mkdir -p data && APP_SERVER_PORT=:18080 APP_DATABASE_URL=file:./data/test.db make dev &
-	@sleep 3
-	@curl -f http://localhost:18080/api/health || (echo "Health check failed" && exit 1)
+	@cd /tmp/testapp-e2e && mkdir -p data && nohup bash -c 'APP_SERVER_PORT=:18080 APP_DATABASE_URL=file:./data/test.db make dev' > /tmp/testapp-e2e.log 2>&1 &
+	@sleep 4
+	@curl -sf http://localhost:18080/api/health || (cat /tmp/testapp-e2e.log && echo "Health check failed" && exit 1)
 	@echo "✅ E2E workflow test passed!"
-	@pkill -f "testapp-e2e.*make dev" || true
-	@rm -rf /tmp/testapp-e2e
+	@-pkill -f "air.*testapp-e2e" 2>/dev/null
+	@-pkill -f "/tmp/testapp-e2e/tmp/main" 2>/dev/null
+	@rm -rf /tmp/testapp-e2e /tmp/testapp-e2e.log 2>/dev/null || true
 
 # Use test-docker-local when:
 # - Testing Docker containerization (build, scan, run)

--- a/internal/generator/template/assets_embed_test.go
+++ b/internal/generator/template/assets_embed_test.go
@@ -1,0 +1,119 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetsEmbedTemplate(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+}
+
+func TestAssetsEmbedPackage(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "package assets", "should be in assets package")
+}
+
+func TestAssetsEmbedHashfsImport(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, `"github.com/benbjohnson/hashfs"`, "should import hashfs")
+}
+
+func TestAssetsEmbedDirective(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "//go:embed all:dist", "should embed dist directory")
+}
+
+func TestAssetsEmbedHashfsInit(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "var fsys *hashfs.FS", "should declare hashfs.FS variable")
+	assert.Contains(t, result, "func init()", "should use init function")
+	assert.Contains(t, result, "hashfs.NewFS", "should wrap with hashfs.NewFS")
+}
+
+func TestAssetsEmbedFileSystem(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "func FileSystem() *hashfs.FS", "should return *hashfs.FS")
+	assert.Contains(t, result, "return fsys", "should return the hashfs filesystem")
+}
+
+func TestAssetsEmbedAssetURL(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "func AssetURL(path string) string", "should have AssetURL function")
+	assert.Contains(t, result, "fsys.HashName(path)", "should use HashName for hashing")
+}
+
+func TestAssetsEmbedConvenienceFunctions(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/assets/embed.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "func CSSURL() string", "should have CSSURL function")
+	assert.Contains(t, result, "func JSURL() string", "should have JSURL function")
+	assert.Contains(t, result, `AssetURL("css/app.css")`, "CSSURL should call AssetURL with css path")
+	assert.Contains(t, result, `AssetURL("js/app.js")`, "JSURL should call AssetURL with js path")
+}

--- a/internal/generator/template/base_layout_test.go
+++ b/internal/generator/template/base_layout_test.go
@@ -1,0 +1,129 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaseLayoutTemplate(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName:  "github.com/example/testapp",
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/http/views/layouts/base.templ.tmpl", data)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+}
+
+func TestBaseLayoutPackage(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName:  "github.com/example/testapp",
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/http/views/layouts/base.templ.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "package layouts", "should be in layouts package")
+}
+
+func TestBaseLayoutAssetsImport(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName:  "github.com/example/testapp",
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/http/views/layouts/base.templ.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, `"github.com/example/testapp/internal/assets"`, "should import assets package")
+}
+
+func TestBaseLayoutCSSURL(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName:  "github.com/example/testapp",
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/http/views/layouts/base.templ.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, `href={ "/assets/" + assets.CSSURL() }`, "should use assets.CSSURL() for stylesheet")
+}
+
+func TestBaseLayoutJSURL(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName:  "github.com/example/testapp",
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/http/views/layouts/base.templ.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, `src={ "/assets/" + assets.JSURL() }`, "should use assets.JSURL() for script")
+}
+
+func TestBaseLayoutNoHardcodedAssetPaths(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+
+	data := TemplateData{
+		ModuleName:  "github.com/example/testapp",
+		ProjectName: "testapp",
+	}
+
+	result, err := renderer.Render("internal/http/views/layouts/base.templ.tmpl", data)
+	require.NoError(t, err)
+
+	assert.NotContains(t, result, `"/assets/css/app.css"`, "should not have hardcoded CSS path")
+	assert.NotContains(t, result, `"/assets/js/app.js"`, "should not have hardcoded JS path")
+}
+
+func TestBaseLayoutModuleNameInterpolation(t *testing.T) {
+	testCases := []struct {
+		name       string
+		moduleName string
+	}{
+		{
+			name:       "simple module",
+			moduleName: "myapp",
+		},
+		{
+			name:       "github module",
+			moduleName: "github.com/user/project",
+		},
+		{
+			name:       "nested module",
+			moduleName: "example.com/org/team/service",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			renderer := NewRenderer(templates.FS)
+			data := TemplateData{
+				ModuleName:  tc.moduleName,
+				ProjectName: "testproject",
+			}
+
+			output, err := renderer.Render("internal/http/views/layouts/base.templ.tmpl", data)
+			require.NoError(t, err)
+
+			expectedAssetsImport := tc.moduleName + "/internal/assets"
+			assert.Contains(t, output, expectedAssetsImport, "should interpolate module name in assets import")
+		})
+	}
+}

--- a/internal/generator/template/templates_server_test.go
+++ b/internal/generator/template/templates_server_test.go
@@ -347,7 +347,7 @@ func TestHTTPRoutesHandleHealthCheckHelper(t *testing.T) {
 	output, err := renderer.Render("internal/http/routes.go.tmpl", data)
 	require.NoError(t, err)
 
-	assert.Contains(t, output, "func (s *Server) handleHealthCheck() http.HandlerFunc", "should have handleHealthCheck helper")
+	assert.Contains(t, output, "func (s *Server) handleHealthCheck() nethttp.HandlerFunc", "should have handleHealthCheck helper")
 	assert.Contains(t, output, "handler := handlers.NewHealthHandler(s.healthService, s.logger)", "should instantiate handler with service and logger")
 	assert.Contains(t, output, "return handler.Check", "should return handler method")
 }
@@ -388,6 +388,56 @@ func TestHTTPRoutesModuleNameInterpolation(t *testing.T) {
 			assert.Contains(t, output, expectedRoutesImport, "should interpolate module name in routes import")
 		})
 	}
+}
+
+func TestHTTPRoutesHashfsImport(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+	data := TemplateData{
+		ModuleName: "github.com/example/testapp",
+	}
+
+	output, err := renderer.Render("internal/http/routes.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, output, `"github.com/benbjohnson/hashfs"`, "should import hashfs package")
+}
+
+func TestHTTPRoutesNetHTTPImport(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+	data := TemplateData{
+		ModuleName: "github.com/example/testapp",
+	}
+
+	output, err := renderer.Render("internal/http/routes.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, output, `nethttp "net/http"`, "should import net/http with nethttp alias")
+}
+
+func TestHTTPRoutesAssetsImport(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+	data := TemplateData{
+		ModuleName: "github.com/example/testapp",
+	}
+
+	output, err := renderer.Render("internal/http/routes.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, output, `"github.com/example/testapp/internal/assets"`, "should import assets package")
+}
+
+func TestHTTPRoutesHashfsFileServer(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+	data := TemplateData{
+		ModuleName: "github.com/example/testapp",
+	}
+
+	output, err := renderer.Render("internal/http/routes.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, output, `s.router.Handle("/assets/*"`, "should register /assets/* route")
+	assert.Contains(t, output, `nethttp.StripPrefix("/assets/"`, "should strip /assets/ prefix using nethttp alias")
+	assert.Contains(t, output, `hashfs.FileServer(assets.FileSystem())`, "should use hashfs.FileServer with assets.FileSystem()")
 }
 
 // Server Test Template Tests (internal/http/server_test.go.tmpl)

--- a/internal/templates/project/go.mod.tmpl
+++ b/internal/templates/project/go.mod.tmpl
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	github.com/PuerkitoBio/goquery v1.11.0
+	github.com/benbjohnson/hashfs v0.2.2
 )
 
 tool (

--- a/internal/templates/project/internal/assets/embed.go.tmpl
+++ b/internal/templates/project/internal/assets/embed.go.tmpl
@@ -3,18 +3,35 @@ package assets
 import (
 	"embed"
 	"io/fs"
-	"net/http"
+
+	"github.com/benbjohnson/hashfs"
 )
 
 //go:embed all:dist
 var distFS embed.FS
 
-func FileSystem() http.FileSystem {
+var fsys *hashfs.FS
+
+func init() {
 	stripped, err := fs.Sub(distFS, "dist")
-	// Embedded files are baked into the binary at compile time.
-	// Failure here indicates build corruption, not a recoverable runtime error.
 	if err != nil {
 		panic("failed to create assets filesystem: " + err.Error())
 	}
-	return http.FS(stripped)
+	fsys = hashfs.NewFS(stripped)
+}
+
+func FileSystem() *hashfs.FS {
+	return fsys
+}
+
+func AssetURL(path string) string {
+	return fsys.HashName(path)
+}
+
+func CSSURL() string {
+	return AssetURL("css/app.css")
+}
+
+func JSURL() string {
+	return AssetURL("js/app.js")
 }

--- a/internal/templates/project/internal/http/routes.go.tmpl
+++ b/internal/templates/project/internal/http/routes.go.tmpl
@@ -1,8 +1,9 @@
 package http
 
 import (
-	"net/http"
+	nethttp "net/http"
 
+	"github.com/benbjohnson/hashfs"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"{{.ModuleName}}/internal/assets"
@@ -40,26 +41,25 @@ func (s *Server) routes() {
 
 	s.router.NotFound(s.handleError())
 
-	fileServer := http.FileServer(assets.FileSystem())
-	s.router.Handle("/assets/*", http.StripPrefix("/assets/", fileServer))
+	s.router.Handle("/assets/*", nethttp.StripPrefix("/assets/", hashfs.FileServer(assets.FileSystem())))
 }
 
-func (s *Server) handleHealthCheck() http.HandlerFunc {
+func (s *Server) handleHealthCheck() nethttp.HandlerFunc {
 	handler := handlers.NewHealthHandler(s.healthService, s.logger)
 	return handler.Check
 }
 
-func (s *Server) handleHome(counter handlers.CountGetter) http.HandlerFunc {
+func (s *Server) handleHome(counter handlers.CountGetter) nethttp.HandlerFunc {
 	handler := handlers.NewHomeHandler(s.logger, counter)
 	return handler.ServeHTTP
 }
 
-func (s *Server) handleAbout() http.HandlerFunc {
+func (s *Server) handleAbout() nethttp.HandlerFunc {
 	handler := handlers.NewAboutHandler(s.logger)
 	return handler.ServeHTTP
 }
 
-func (s *Server) handleError() http.HandlerFunc {
+func (s *Server) handleError() nethttp.HandlerFunc {
 	handler := handlers.NewErrorHandler(s.logger)
 	return handler.ServeHTTP
 }

--- a/internal/templates/project/internal/http/views/layouts/base.templ.tmpl
+++ b/internal/templates/project/internal/http/views/layouts/base.templ.tmpl
@@ -3,6 +3,7 @@ package layouts
 import (
 	"time"
 
+	"{{.ModuleName}}/internal/assets"
 	"{{.ModuleName}}/internal/http/routes"
 	"{{.ModuleName}}/internal/http/views/components"
 )
@@ -15,9 +16,9 @@ templ Base(title, description string) {
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<title>{ title }</title>
 			<meta name="description" content={ description }/>
-			<link rel="stylesheet" href="/assets/css/app.css"/>
+			<link rel="stylesheet" href={ "/assets/" + assets.CSSURL() }/>
 			@components.HTMXConfig()
-			<script src="/assets/js/app.js" nonce={ templ.GetNonce(ctx) } defer></script>
+			<script src={ "/assets/" + assets.JSURL() } nonce={ templ.GetNonce(ctx) } defer></script>
 		</head>
 		<body>
 			@components.Nav(components.NavProps{


### PR DESCRIPTION
## What

Adds hashfs integration for content-addressed static asset serving in generated projects.

## Why

Enables aggressive browser caching (1-year max-age) by embedding SHA256 hashes in asset URLs. When files change, URLs change automatically, eliminating cache invalidation issues.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)
- [x] Integration tests pass
- [x] E2E local tests pass

## Notes

- Uses hashfs v0.2.2
- Added `nethttp` alias to avoid shadowing `net/http` in generated `routes.go`
- Fixed `make test-e2e-local` cleanup to properly exit with code 0

Closes #411
Closes #412
Closes #413
Closes #414
Closes #415
Closes #416