### PR TITLE
feat: add HTTP compression middleware for generated projects

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -117,6 +117,7 @@ func (g *projectGenerator) Generate(ctx context.Context, cfg any) error {
 		"internal/http/views/pages/error.templ.tmpl":          "internal/http/views/pages/error.templ",
 		"internal/http/middleware/logging.go.tmpl":        "internal/http/middleware/logging.go",
 		"internal/http/middleware/security.go.tmpl":       "internal/http/middleware/security.go",
+		"internal/http/middleware/compress.go.tmpl":       "internal/http/middleware/compress.go",
 		"internal/db/db.go.tmpl":                        "internal/db/db.go",
 		"internal/db/queries/.gitkeep.tmpl":             "internal/db/queries/.gitkeep",
 		"internal/db/queries/health.sql.tmpl":           "internal/db/queries/health.sql",

--- a/internal/generator/template/compress_middleware_test.go
+++ b/internal/generator/template/compress_middleware_test.go
@@ -1,0 +1,97 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/templates"
+	"github.com/anomalousventures/tracks/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderCompressMiddlewareTemplate(t *testing.T, moduleName string) string {
+	t.Helper()
+	renderer := NewRenderer(templates.FS)
+	data := TemplateData{ModuleName: moduleName}
+	result, err := renderer.Render("internal/http/middleware/compress.go.tmpl", data)
+	require.NoError(t, err)
+	return result
+}
+
+func TestCompressMiddlewareTemplate(t *testing.T) {
+	tests := []struct {
+		name       string
+		moduleName string
+	}{
+		{"github module", "github.com/user/project"},
+		{"gitlab module", "gitlab.com/org/service"},
+		{"simple name", "myapp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderCompressMiddlewareTemplate(t, tt.moduleName)
+			assert.NotEmpty(t, result)
+		})
+	}
+}
+
+func TestCompressMiddlewareValidGoCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		moduleName string
+	}{
+		{"github module", "github.com/user/project"},
+		{"gitlab module", "gitlab.com/org/service"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderCompressMiddlewareTemplate(t, tt.moduleName)
+			testutil.AssertValidGoCode(t, result, "compress.go")
+		})
+	}
+}
+
+func TestCompressMiddlewarePackageDeclaration(t *testing.T) {
+	result := renderCompressMiddlewareTemplate(t, "github.com/user/project")
+	assert.Contains(t, result, "package middleware")
+}
+
+func TestCompressMiddlewareImports(t *testing.T) {
+	result := renderCompressMiddlewareTemplate(t, "github.com/user/project")
+
+	testutil.AssertContainsAll(t, result, []string{
+		`"net/http"`,
+		`"github.com/go-chi/chi/v5/middleware"`,
+	})
+}
+
+func TestCompressMiddlewareNewCompressMiddleware(t *testing.T) {
+	result := renderCompressMiddlewareTemplate(t, "github.com/user/project")
+
+	testutil.AssertContainsAll(t, result, []string{
+		"func NewCompressMiddleware() func(next http.Handler) http.Handler",
+		"return middleware.Compress(5,",
+	})
+}
+
+func TestCompressMiddlewareContentTypes(t *testing.T) {
+	result := renderCompressMiddlewareTemplate(t, "github.com/user/project")
+
+	testutil.AssertContainsAll(t, result, []string{
+		`"text/html"`,
+		`"text/css"`,
+		`"text/plain"`,
+		`"text/javascript"`,
+		`"application/javascript"`,
+		`"application/json"`,
+		`"application/xml"`,
+		`"image/svg+xml"`,
+	})
+}
+
+func TestCompressMiddlewareCompressionLevel(t *testing.T) {
+	result := renderCompressMiddlewareTemplate(t, "github.com/user/project")
+	assert.Contains(t, result, "middleware.Compress(5,")
+}

--- a/internal/generator/template/templates_server_test.go
+++ b/internal/generator/template/templates_server_test.go
@@ -267,13 +267,27 @@ func TestHTTPRoutesMiddlewareOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	requestIDIdx := strings.Index(output, "middleware.RequestID")
+	compressIdx := strings.Index(output, "httpmiddleware.NewCompressMiddleware()")
 	loggerIdx := strings.Index(output, "httpmiddleware.NewRequestLogger(s.logger)")
 	realIPIdx := strings.Index(output, "middleware.RealIP")
 	recovererIdx := strings.Index(output, "httpmiddleware.NewRecoverer(s.logger)")
 
-	assert.Greater(t, loggerIdx, requestIDIdx, "RequestLogger should come after RequestID")
+	assert.Greater(t, compressIdx, requestIDIdx, "Compress should come after RequestID")
+	assert.Greater(t, loggerIdx, compressIdx, "RequestLogger should come after Compress")
 	assert.Greater(t, realIPIdx, loggerIdx, "RealIP should come after RequestLogger")
 	assert.Greater(t, recovererIdx, realIPIdx, "Recoverer should come after RealIP")
+}
+
+func TestHTTPRoutesCompressMiddleware(t *testing.T) {
+	renderer := NewRenderer(templates.FS)
+	data := TemplateData{
+		ModuleName: "github.com/example/testapp",
+	}
+
+	output, err := renderer.Render("internal/http/routes.go.tmpl", data)
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "httpmiddleware.NewCompressMiddleware()", "should use compress middleware")
 }
 
 func TestHTTPRoutesMarkerSections(t *testing.T) {

--- a/internal/templates/project/internal/http/middleware/compress.go.tmpl
+++ b/internal/templates/project/internal/http/middleware/compress.go.tmpl
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func NewCompressMiddleware() func(next http.Handler) http.Handler {
+	return middleware.Compress(5,
+		"text/html",
+		"text/css",
+		"text/plain",
+		"text/javascript",
+		"application/javascript",
+		"application/json",
+		"application/xml",
+		"image/svg+xml",
+	)
+}

--- a/internal/templates/project/internal/http/routes.go.tmpl
+++ b/internal/templates/project/internal/http/routes.go.tmpl
@@ -14,6 +14,7 @@ import (
 
 func (s *Server) routes() {
 	s.router.Use(middleware.RequestID)
+	s.router.Use(httpmiddleware.NewCompressMiddleware())
 	s.router.Use(httpmiddleware.NewRequestLogger(s.logger))
 	s.router.Use(middleware.RealIP)
 	s.router.Use(httpmiddleware.NewRecoverer(s.logger))


### PR DESCRIPTION
## Summary
- Add gzip compression middleware template (`compress.go.tmpl`) wrapping Chi's built-in `middleware.Compress(5, ...)`
- Wire compression into the middleware chain in `routes.go.tmpl` (after RequestID, before logger)
- Register template in `generator.go` for project generation
- Add comprehensive template tests for compression middleware

## Implementation Details
Uses Chi's built-in compression at level 5 (balanced CPU/ratio) for compressible content types:
- `text/html`, `text/css`, `text/plain`, `text/javascript`
- `application/javascript`, `application/json`, `application/xml`
- `image/svg+xml`

## Test plan
- [x] `make generate-mocks` passes
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make test-integration` passes
- [x] `make test-e2e-local` passes
- [ ] CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)