### PR TITLE
feat: add templui tool directive to go.mod template

### DIFF
--- a/internal/templates/project/go.mod.tmpl
+++ b/internal/templates/project/go.mod.tmpl
@@ -24,6 +24,7 @@ require (
 tool (
 	github.com/a-h/templ/cmd/templ
 	github.com/sqlc-dev/sqlc/cmd/sqlc
+	github.com/templui/templui/cmd/templui
 	github.com/vektra/mockery/v3
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/air-verse/air


### PR DESCRIPTION
## Summary

Adds `github.com/templui/templui/cmd/templui` to the tool block in `go.mod.tmpl` to enable templui code generation in generated projects.

## Changes

- Added templui tool directive to `internal/templates/project/go.mod.tmpl`
- Positioned alphabetically in the tool block after sqlc

## Testing

- ✅ `make generate-mocks` - passed
- ✅ `make lint-go` - passed
- ✅ `make lint-mocks` - passed
- ✅ `make test` - passed (167s)
- ✅ `make test-integration` - passed (120s)

Closes #462

🤖 Generated with [Claude Code](https://claude.ai/code)