### PR TITLE
docs: fix sidebar and rewrite example walkthrough with templ/HTMX patterns

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -31,6 +31,8 @@ const sidebars = {
         'guides/troubleshooting-routing',
         'guides/patterns',
         'guides/testing',
+        'guides/development-workflow',
+        'guides/caching',
       ],
     },
     {


### PR DESCRIPTION
## What

- Add missing sidebar entries for `development-workflow` and `caching` guides
- Rewrite example-walkthrough Steps 6-7 to use templ/HTMX patterns instead of JSON API
- Add new Step 8 with templUI component examples

## Why

The generated README.md referenced two documentation pages that weren't accessible from the sidebar, causing 404 errors for users. Additionally, the example walkthrough had warning banners acknowledging that Steps 6-7 showed incorrect JSON API patterns instead of the correct templ/HTMX hypermedia patterns.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)
- [x] `make lint-md` passes with 0 errors

## Notes

The example walkthrough is now forward-looking and references templUI components from Epic 1.5, which are currently being implemented. The patterns shown match what generated projects will produce once templUI integration is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)