### PR TITLE
feat: wire templui execution into ProjectGenerator (#465)

### DIFF
--- a/tests/integration/asset_pipeline_test.go
+++ b/tests/integration/asset_pipeline_test.go
@@ -203,6 +203,24 @@ func TestAssetPipeline(t *testing.T) {
 		assert.True(t, found, "Air pre_cmd should include 'make generate assets'")
 	})
 
+	t.Run("templUI configuration (#465)", func(t *testing.T) {
+		templuiConfig := filepath.Join(projectRoot, ".templui.json")
+		content, err := os.ReadFile(templuiConfig)
+		require.NoError(t, err, ".templui.json should exist")
+
+		configStr := string(content)
+		assert.Contains(t, configStr, "componentsDir",
+			".templui.json should define components directory")
+		assert.Contains(t, configStr, "internal/http/views/components/ui",
+			".templui.json should point to correct ui directory")
+		assert.Contains(t, configStr, "internal/http/views/components/utils",
+			".templui.json should point to correct utils directory")
+		assert.Contains(t, configStr, "github.com/test/asset-pipeline-test",
+			".templui.json should contain module name")
+		assert.Contains(t, configStr, "internal/assets/web/js",
+			".templui.json should define jsDir for JavaScript assets")
+	})
+
 	t.Run("complete asset pipeline (#452)", func(t *testing.T) {
 		webCSSDir := filepath.Join(projectRoot, "internal", "assets", "web", "css")
 		webJSDir := filepath.Join(projectRoot, "internal", "assets", "web", "js")


### PR DESCRIPTION
## What

Wire templUI execution into the ProjectGenerator to automatically install a curated set of 20 UI components during project generation.

Changes:
- Add `TemplUIComponents` constant with 20 starter components
- Wire `.templui.json.tmpl` into preGenerateTemplates
- Execute `templui -f init` to install utils (TwMerge function)
- Execute `templui add` with all components
- Run `gofmt -w` on components directory to fix icon file formatting issues

## Why

Closes #465. This completes Epic 1.5 (Templ-UI Integration) by ensuring generated projects have templUI components installed and ready to use out of the box.

## Testing

- [x] Tests pass locally (`make test`)
- [x] Integration tests pass (`make test-integration`)
- [x] E2E test passes with linter check
- [x] Linting passes (`make lint`)

## Notes

The icon component installed by templUI has formatting issues that require running `gofmt -w` after installation. This is handled automatically during project generation.