### PR TITLE
feat: migrate about.templ to use templUI components

### DIFF
--- a/internal/templates/project/internal/http/views/pages/about.templ.tmpl
+++ b/internal/templates/project/internal/http/views/pages/about.templ.tmpl
@@ -1,16 +1,21 @@
 package pages
 
-import "{{ .ModuleName }}/internal/http/views/layouts"
+import (
+	"{{ .ModuleName }}/internal/http/views/components/ui/card"
+	"{{ .ModuleName }}/internal/http/views/layouts"
+)
 
 templ aboutContent() {
 	<main class="container-app py-8">
 		<header class="mb-8">
 			<h1 class="page-header">About This Application</h1>
 		</header>
-		<section class="card">
-			<p class="text-muted mb-4">This application was generated using Tracks.</p>
-			<p class="text-muted">Edit this template at <code class="bg-[var(--muted)] px-2 py-1 rounded text-sm">internal/http/views/pages/about.templ</code> to customize your about page.</p>
-		</section>
+		@card.Card() {
+			@card.Content() {
+				<p class="text-muted mb-4">This application was generated using Tracks.</p>
+				<p class="text-muted">Edit this template at <code class="bg-[var(--muted)] px-2 py-1 rounded text-sm">internal/http/views/pages/about.templ</code> to customize your about page.</p>
+			}
+		}
 	</main>
 }
 


### PR DESCRIPTION
## Summary
Updates the about page template to use templUI components following the pattern established in PR #491.

## Changes
- Updated `about.templ.tmpl` to import and use `ui/card` components
- Wrapped content in `@card.Card()` and `@card.Content()`
- Maintains existing content and styling

## Testing
- ✅ All unit tests passed
- ✅ All integration tests passed
- ✅ Linting passed

Closes #467

Generated with [Claude Code](https://claude.ai/code)