### PR TITLE
feat: add script injection markers to base.templ

### DIFF
--- a/internal/templates/project/internal/http/views/layouts/base.templ.tmpl
+++ b/internal/templates/project/internal/http/views/layouts/base.templ.tmpl
@@ -21,6 +21,8 @@ templ Base(title, description string) {
 			<script src={ "/assets/" + assets.JSURL() } nonce={ templ.GetNonce(ctx) } defer></script>
 		</head>
 		<body>
+			<!-- TRACKS:UI_SCRIPTS:BEGIN -->
+			<!-- TRACKS:UI_SCRIPTS:END -->
 			@components.Nav(components.NavProps{
 				Logo: "{{.ProjectName}}",
 				Links: []components.NavLink{


### PR DESCRIPTION
## What

Add TRACKS:UI_SCRIPTS comment markers to base.templ.tmpl for templUI component script injection.

## Why

templUI components with JS have a `Script()` templ function that must be called in the layout. The `tracks ui add` command needs markers to know where to inject these script calls when adding components that require JavaScript.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)
- [x] Verified markers present in generated project (`make test-gen-app`)

## Notes

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)