### PR TITLE
feat: add tracks ui subcommands for templUI integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint-go: ## Run golangci-lint
 lint-mocks: ## Check that generated mocks are up-to-date
 	@echo "Checking generated mocks are up-to-date..."
 	@go tool mockery
-	@if [ -n "$$(git status --porcelain tests/mocks)" ]; then \
+	@if ! git diff --quiet tests/mocks; then \
 		echo "❌ Generated mocks are out of date. Run 'make generate-mocks' and commit the changes."; \
 		git diff tests/mocks; \
 		exit 1; \

--- a/internal/cli/commands/ui.go
+++ b/internal/cli/commands/ui.go
@@ -45,15 +45,30 @@ This command must be run from within a Tracks project (containing .tracks.yaml).
 		Example: `  # Show templUI version
   tracks ui --version
 
-  # Add a button component (future)
+  # Add a button component
   tracks ui add button
 
-  # List available components (future)
-  tracks ui list`,
+  # Add multiple components
+  tracks ui add button card toast
+
+  # List available components
+  tracks ui list
+
+  # Upgrade templUI to latest
+  tracks ui upgrade`,
 		Run: c.run,
 	}
 
 	cmd.Flags().Bool("version", false, "Show templUI version")
+
+	addCmd := NewUIAddCommand(c.detector, c.executor, c.newRenderer, c.flushRenderer)
+	cmd.AddCommand(addCmd.Command())
+
+	listCmd := NewUIListCommand(c.detector, c.executor, c.newRenderer, c.flushRenderer)
+	cmd.AddCommand(listCmd.Command())
+
+	upgradeCmd := NewUIUpgradeCommand(c.detector, c.executor, c.newRenderer, c.flushRenderer)
+	cmd.AddCommand(upgradeCmd.Command())
 
 	return cmd
 }

--- a/internal/cli/commands/ui_add.go
+++ b/internal/cli/commands/ui_add.go
@@ -1,0 +1,204 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/anomalousventures/tracks/internal/cli/interfaces"
+	"github.com/spf13/cobra"
+)
+
+const (
+	scriptMarkerBegin = "<!-- TRACKS:UI_SCRIPTS:BEGIN -->"
+	scriptMarkerEnd   = "<!-- TRACKS:UI_SCRIPTS:END -->"
+)
+
+// UIAddCommand represents the 'ui add' subcommand for adding templUI components.
+type UIAddCommand struct {
+	detector      interfaces.ProjectDetector
+	executor      interfaces.UIExecutor
+	newRenderer   RendererFactory
+	flushRenderer RendererFlusher
+}
+
+// NewUIAddCommand creates a new instance of the 'ui add' command with injected dependencies.
+func NewUIAddCommand(
+	detector interfaces.ProjectDetector,
+	executor interfaces.UIExecutor,
+	newRenderer RendererFactory,
+	flushRenderer RendererFlusher,
+) *UIAddCommand {
+	return &UIAddCommand{
+		detector:      detector,
+		executor:      executor,
+		newRenderer:   newRenderer,
+		flushRenderer: flushRenderer,
+	}
+}
+
+// Command returns the cobra.Command for the 'ui add' subcommand.
+func (c *UIAddCommand) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add[@<ref>] <component> [component...]",
+		Short: "Add templUI components to your project",
+		Long: `Add one or more templUI components to your Tracks project.
+
+Components are copied to your project's internal/http/views/components/ui/
+directory. If a component has a Script() function, it will be automatically
+injected into your base.templ layout between the TRACKS:UI_SCRIPTS markers.
+
+The optional @ref syntax allows you to specify a templUI version:
+  tracks ui add@v0.1.0 button    # Use specific version
+  tracks ui add button           # Use current version`,
+		Example: `  # Add a single component
+  tracks ui add button
+
+  # Add multiple components
+  tracks ui add button card toast
+
+  # Add components from a specific version
+  tracks ui add@v0.1.0 button card
+
+  # Force overwrite existing components
+  tracks ui add button --force`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: c.runE,
+	}
+
+	cmd.Flags().BoolP("force", "f", false, "Overwrite existing components without prompting")
+
+	return cmd
+}
+
+func (c *UIAddCommand) runE(cmd *cobra.Command, args []string) error {
+	r := c.newRenderer(cmd)
+	ctx := cmd.Context()
+	defer c.flushRenderer(cmd, r)
+
+	project, projectDir, err := c.detector.Detect(ctx, ".")
+	if err != nil {
+		r.Section(interfaces.Section{
+			Body: fmt.Sprintf("Error: %v", err),
+		})
+		return nil
+	}
+	if project == nil {
+		r.Section(interfaces.Section{
+			Body: "Error: not in a Tracks project (no .tracks.yaml found)",
+		})
+		return nil
+	}
+
+	ref := parseRefFromUse(cmd.Use, cmd.CalledAs())
+	force, _ := cmd.Flags().GetBool("force")
+
+	r.Title("Adding templUI components")
+
+	if err := c.executor.Add(ctx, projectDir, ref, args, force); err != nil {
+		r.Section(interfaces.Section{
+			Body: fmt.Sprintf("Error: %v", err),
+		})
+		return nil
+	}
+
+	injectedScripts := c.injectScripts(projectDir, args)
+
+	var body strings.Builder
+	body.WriteString(fmt.Sprintf("Added %d component(s): %s", len(args), strings.Join(args, ", ")))
+	if len(injectedScripts) > 0 {
+		body.WriteString(fmt.Sprintf("\nInjected scripts: %s", strings.Join(injectedScripts, ", ")))
+	}
+
+	r.Section(interfaces.Section{
+		Body: body.String(),
+	})
+
+	return nil
+}
+
+func (c *UIAddCommand) injectScripts(projectDir string, components []string) []string {
+	baseTemplPath := filepath.Join(projectDir, "internal", "http", "views", "layouts", "base.templ")
+	uiDir := filepath.Join(projectDir, "internal", "http", "views", "components", "ui")
+
+	baseContent, err := os.ReadFile(baseTemplPath)
+	if err != nil {
+		return nil
+	}
+
+	var injectedScripts []string
+	contentStr := string(baseContent)
+
+	for _, component := range components {
+		componentFile := filepath.Join(uiDir, component+".templ")
+		scriptFuncName := capitalizeFirst(component) + "Script"
+
+		if !hasScriptFunc(componentFile, scriptFuncName) {
+			continue
+		}
+
+		scriptCall := fmt.Sprintf("@ui.%s()", scriptFuncName)
+		if strings.Contains(contentStr, scriptCall) {
+			continue
+		}
+
+		contentStr = injectScriptCall(contentStr, scriptCall)
+		injectedScripts = append(injectedScripts, scriptFuncName)
+	}
+
+	if len(injectedScripts) > 0 {
+		_ = os.WriteFile(baseTemplPath, []byte(contentStr), 0644)
+	}
+
+	return injectedScripts
+}
+
+func hasScriptFunc(componentFile, funcName string) bool {
+	content, err := os.ReadFile(componentFile)
+	if err != nil {
+		return false
+	}
+
+	pattern := fmt.Sprintf(`(?m)^(templ|func)\s+%s\s*\(`, regexp.QuoteMeta(funcName))
+	re := regexp.MustCompile(pattern)
+	return re.Match(content)
+}
+
+func injectScriptCall(content, scriptCall string) string {
+	beginIdx := strings.Index(content, scriptMarkerBegin)
+	endIdx := strings.Index(content, scriptMarkerEnd)
+
+	if beginIdx == -1 || endIdx == -1 || endIdx <= beginIdx {
+		return content
+	}
+
+	insertPos := beginIdx + len(scriptMarkerBegin)
+
+	indentation := "\t\t\t"
+	if lineStart := strings.LastIndex(content[:beginIdx], "\n"); lineStart != -1 {
+		lineContent := content[lineStart+1 : beginIdx]
+		indentation = strings.TrimSuffix(lineContent, strings.TrimLeft(lineContent, " \t"))
+	}
+
+	newLine := "\n" + indentation + scriptCall
+	return content[:insertPos] + newLine + content[insertPos:]
+}
+
+func capitalizeFirst(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(string(s[0])) + s[1:]
+}
+
+func parseRefFromUse(useStr, calledAs string) string {
+	if calledAs == useStr || strings.Contains(calledAs, "<") {
+		return ""
+	}
+	if idx := strings.Index(calledAs, "@"); idx != -1 {
+		return calledAs[idx+1:]
+	}
+	return ""
+}

--- a/internal/cli/commands/ui_add_test.go
+++ b/internal/cli/commands/ui_add_test.go
@@ -1,0 +1,381 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/cli/interfaces"
+	"github.com/anomalousventures/tracks/tests/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupUIAddTestCommand(t *testing.T) (*cobra.Command, *mocks.MockUIExecutor, *mocks.MockProjectDetector, *mocks.MockRenderer) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	factory := func(*cobra.Command) interfaces.Renderer {
+		return mockRenderer
+	}
+	flusher := func(*cobra.Command, interfaces.Renderer) {
+		mockRenderer.Flush()
+	}
+
+	cmd := NewUIAddCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	return cobraCmd, mockExecutor, mockDetector, mockRenderer
+}
+
+func TestUIAddCommand_Command(t *testing.T) {
+	cobraCmd, _, _, _ := setupUIAddTestCommand(t)
+
+	if cobraCmd == nil {
+		t.Fatal("Command() returned nil")
+	}
+
+	if !strings.HasPrefix(cobraCmd.Use, "add") {
+		t.Errorf("expected Use to start with 'add', got %q", cobraCmd.Use)
+	}
+
+	if cobraCmd.Short == "" {
+		t.Error("Short description is empty")
+	}
+
+	if cobraCmd.Long == "" {
+		t.Error("Long description is empty")
+	}
+
+	if cobraCmd.Example == "" {
+		t.Error("Example is empty")
+	}
+
+	forceFlag := cobraCmd.Flags().Lookup("force")
+	if forceFlag == nil {
+		t.Fatal("--force flag not found")
+	}
+	if forceFlag.Shorthand != "f" {
+		t.Errorf("expected --force shorthand 'f', got %q", forceFlag.Shorthand)
+	}
+}
+
+func TestUIAddCommand_Run_NotInProject(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(nil, "", nil).Once()
+
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "not in a Tracks project")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIAddCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	cobraCmd.SetArgs([]string{"button"})
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockDetector.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIAddCommand_Run_Success(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("Add", mock.Anything, "/tmp/testapp", "", []string{"button"}, false).
+		Return(nil).Once()
+
+	mockRenderer.On("Title", "Adding templUI components").Once()
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Added 1 component(s)") &&
+			strings.Contains(s.Body, "button")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIAddCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	cobraCmd.SetArgs([]string{"button"})
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+	mockDetector.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIAddCommand_Run_WithForceFlag(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("Add", mock.Anything, "/tmp/testapp", "", []string{"button"}, true).
+		Return(nil).Once()
+
+	mockRenderer.On("Title", mock.Anything).Once()
+	mockRenderer.On("Section", mock.Anything).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIAddCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	cobraCmd.SetArgs([]string{"button", "--force"})
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+}
+
+func TestUIAddCommand_Run_MultipleComponents(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("Add", mock.Anything, "/tmp/testapp", "", []string{"button", "card", "toast"}, false).
+		Return(nil).Once()
+
+	mockRenderer.On("Title", mock.Anything).Once()
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Added 3 component(s)")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIAddCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	cobraCmd.SetArgs([]string{"button", "card", "toast"})
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+}
+
+func TestUIAddCommand_Run_ExecutorError(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("Add", mock.Anything, "/tmp/testapp", "", []string{"button"}, false).
+		Return(errors.New("component not found")).Once()
+
+	mockRenderer.On("Title", mock.Anything).Once()
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Error:") && strings.Contains(s.Body, "component not found")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIAddCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	cobraCmd.SetArgs([]string{"button"})
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIAddCommand_Run_NoComponents(t *testing.T) {
+	cobraCmd, _, _, _ := setupUIAddTestCommand(t)
+
+	cobraCmd.SetArgs([]string{})
+	err := cobraCmd.Execute()
+	if err == nil {
+		t.Error("expected error for missing arguments")
+	}
+}
+
+func TestHasScriptFunc(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		funcName string
+		expected bool
+	}{
+		{
+			name:     "templ declaration",
+			content:  "templ ToastScript() {\n\t<script>\n\t</script>\n}",
+			funcName: "ToastScript",
+			expected: true,
+		},
+		{
+			name:     "func declaration",
+			content:  "func ButtonScript() templ.Component {\n\treturn nil\n}",
+			funcName: "ButtonScript",
+			expected: true,
+		},
+		{
+			name:     "no script function",
+			content:  "templ Button() {\n\t<button>Click</button>\n}",
+			funcName: "ButtonScript",
+			expected: false,
+		},
+		{
+			name:     "different function name",
+			content:  "templ CardScript() {\n\t<script>\n\t</script>\n}",
+			funcName: "ButtonScript",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "component.templ")
+			if err := os.WriteFile(tmpFile, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+
+			result := hasScriptFunc(tmpFile, tt.funcName)
+			if result != tt.expected {
+				t.Errorf("hasScriptFunc() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInjectScriptCall(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		scriptCall string
+		expected   string
+	}{
+		{
+			name: "inject between markers",
+			content: `<body>
+			<!-- TRACKS:UI_SCRIPTS:BEGIN -->
+			<!-- TRACKS:UI_SCRIPTS:END -->
+		</body>`,
+			scriptCall: "@ui.ToastScript()",
+			expected: `<body>
+			<!-- TRACKS:UI_SCRIPTS:BEGIN -->
+			@ui.ToastScript()
+			<!-- TRACKS:UI_SCRIPTS:END -->
+		</body>`,
+		},
+		{
+			name:       "no markers",
+			content:    "<body></body>",
+			scriptCall: "@ui.ToastScript()",
+			expected:   "<body></body>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := injectScriptCall(tt.content, tt.scriptCall)
+			if result != tt.expected {
+				t.Errorf("injectScriptCall() =\n%s\n\nexpected:\n%s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCapitalizeFirst(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"button", "Button"},
+		{"toast", "Toast"},
+		{"", ""},
+		{"B", "B"},
+		{"BUTTON", "BUTTON"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := capitalizeFirst(tt.input)
+			if result != tt.expected {
+				t.Errorf("capitalizeFirst(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseRefFromUse(t *testing.T) {
+	tests := []struct {
+		name     string
+		useStr   string
+		calledAs string
+		expected string
+	}{
+		{"no ref", "add", "add", ""},
+		{"with ref", "add[@<ref>]", "add@v0.1.0", "v0.1.0"},
+		{"just add", "add", "add", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseRefFromUse(tt.useStr, tt.calledAs)
+			if result != tt.expected {
+				t.Errorf("parseRefFromUse(%q, %q) = %q, expected %q", tt.useStr, tt.calledAs, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/cli/commands/ui_list.go
+++ b/internal/cli/commands/ui_list.go
@@ -1,0 +1,135 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/anomalousventures/tracks/internal/cli/interfaces"
+	"github.com/spf13/cobra"
+)
+
+// UIListCommand represents the 'ui list' subcommand for listing templUI components.
+type UIListCommand struct {
+	detector      interfaces.ProjectDetector
+	executor      interfaces.UIExecutor
+	newRenderer   RendererFactory
+	flushRenderer RendererFlusher
+}
+
+// NewUIListCommand creates a new instance of the 'ui list' command with injected dependencies.
+func NewUIListCommand(
+	detector interfaces.ProjectDetector,
+	executor interfaces.UIExecutor,
+	newRenderer RendererFactory,
+	flushRenderer RendererFlusher,
+) *UIListCommand {
+	return &UIListCommand{
+		detector:      detector,
+		executor:      executor,
+		newRenderer:   newRenderer,
+		flushRenderer: flushRenderer,
+	}
+}
+
+// Command returns the cobra.Command for the 'ui list' subcommand.
+func (c *UIListCommand) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list[@<ref>]",
+		Short: "List available templUI components",
+		Long: `List all available templUI components and show which ones are installed.
+
+Components that are already installed in your project are marked with ✓.
+Use the optional @ref syntax to list components from a specific templUI version.`,
+		Example: `  # List available components
+  tracks ui list
+
+  # List components from a specific version
+  tracks ui list@v0.1.0`,
+		RunE: c.runE,
+	}
+
+	return cmd
+}
+
+func (c *UIListCommand) runE(cmd *cobra.Command, args []string) error {
+	r := c.newRenderer(cmd)
+	ctx := cmd.Context()
+	defer c.flushRenderer(cmd, r)
+
+	project, projectDir, err := c.detector.Detect(ctx, ".")
+	if err != nil {
+		r.Section(interfaces.Section{
+			Body: fmt.Sprintf("Error: %v", err),
+		})
+		return nil
+	}
+	if project == nil {
+		r.Section(interfaces.Section{
+			Body: "Error: not in a Tracks project (no .tracks.yaml found)",
+		})
+		return nil
+	}
+
+	ref := parseRefFromUse(cmd.Use, cmd.CalledAs())
+
+	components, err := c.executor.List(ctx, projectDir, ref)
+	if err != nil {
+		r.Section(interfaces.Section{
+			Body: fmt.Sprintf("Error: %v", err),
+		})
+		return nil
+	}
+
+	installedComponents := getInstalledComponents(projectDir)
+
+	for i := range components {
+		if installedComponents[components[i].Name] {
+			components[i].Installed = true
+		}
+	}
+
+	r.Title("Available templUI Components")
+
+	headers := []string{"NAME", "CATEGORY", "INSTALLED"}
+	rows := make([][]string, len(components))
+	for i, comp := range components {
+		installed := "-"
+		if comp.Installed {
+			installed = "✓"
+		}
+		category := comp.Category
+		if category == "" {
+			category = "-"
+		}
+		rows[i] = []string{comp.Name, category, installed}
+	}
+
+	r.Table(interfaces.Table{
+		Headers: headers,
+		Rows:    rows,
+	})
+
+	return nil
+}
+
+func getInstalledComponents(projectDir string) map[string]bool {
+	uiDir := filepath.Join(projectDir, "internal", "http", "views", "components", "ui")
+	installed := make(map[string]bool)
+
+	entries, err := os.ReadDir(uiDir)
+	if err != nil {
+		return installed
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".templ") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".templ")
+		installed[name] = true
+	}
+
+	return installed
+}

--- a/internal/cli/commands/ui_list_test.go
+++ b/internal/cli/commands/ui_list_test.go
@@ -1,0 +1,244 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/cli/interfaces"
+	"github.com/anomalousventures/tracks/tests/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupUIListTestCommand(t *testing.T) (*cobra.Command, *mocks.MockUIExecutor, *mocks.MockProjectDetector, *mocks.MockRenderer) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	factory := func(*cobra.Command) interfaces.Renderer {
+		return mockRenderer
+	}
+	flusher := func(*cobra.Command, interfaces.Renderer) {
+		mockRenderer.Flush()
+	}
+
+	cmd := NewUIListCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	return cobraCmd, mockExecutor, mockDetector, mockRenderer
+}
+
+func TestUIListCommand_Command(t *testing.T) {
+	cobraCmd, _, _, _ := setupUIListTestCommand(t)
+
+	if cobraCmd == nil {
+		t.Fatal("Command() returned nil")
+	}
+
+	if !strings.HasPrefix(cobraCmd.Use, "list") {
+		t.Errorf("expected Use to start with 'list', got %q", cobraCmd.Use)
+	}
+
+	if cobraCmd.Short == "" {
+		t.Error("Short description is empty")
+	}
+
+	if cobraCmd.Long == "" {
+		t.Error("Long description is empty")
+	}
+
+	if cobraCmd.Example == "" {
+		t.Error("Example is empty")
+	}
+}
+
+func TestUIListCommand_Run_NotInProject(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(nil, "", nil).Once()
+
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "not in a Tracks project")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIListCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockDetector.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIListCommand_Run_Success(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	components := []interfaces.UIComponent{
+		{Name: "button", Category: "Forms", Installed: false},
+		{Name: "card", Category: "Layout", Installed: false},
+	}
+	mockExecutor.On("List", mock.Anything, "/tmp/testapp", "").
+		Return(components, nil).Once()
+
+	mockRenderer.On("Title", "Available templUI Components").Once()
+	mockRenderer.On("Table", mock.MatchedBy(func(t interfaces.Table) bool {
+		return len(t.Headers) == 3 && len(t.Rows) == 2
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIListCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+	mockDetector.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIListCommand_Run_ExecutorError(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("List", mock.Anything, "/tmp/testapp", "").
+		Return(nil, errors.New("failed to list components")).Once()
+
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Error:") && strings.Contains(s.Body, "failed to list components")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIListCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIListCommand_TableContent(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	components := []interfaces.UIComponent{
+		{Name: "button", Category: "Forms", Installed: false},
+		{Name: "toast", Category: "Feedback", Installed: false},
+	}
+	mockExecutor.On("List", mock.Anything, "/tmp/testapp", "").
+		Return(components, nil).Once()
+
+	var capturedTable interfaces.Table
+	mockRenderer.On("Title", mock.Anything).Once()
+	mockRenderer.On("Table", mock.Anything).Run(func(args mock.Arguments) {
+		capturedTable = args.Get(0).(interfaces.Table)
+	}).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIListCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	if len(capturedTable.Headers) != 3 {
+		t.Errorf("expected 3 headers, got %d", len(capturedTable.Headers))
+	}
+	if capturedTable.Headers[0] != "NAME" {
+		t.Errorf("expected first header 'NAME', got %q", capturedTable.Headers[0])
+	}
+	if len(capturedTable.Rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(capturedTable.Rows))
+	}
+	if capturedTable.Rows[0][0] != "button" {
+		t.Errorf("expected first row name 'button', got %q", capturedTable.Rows[0][0])
+	}
+}
+
+func TestGetInstalledComponents(t *testing.T) {
+	tmpDir := t.TempDir()
+	uiDir := filepath.Join(tmpDir, "internal", "http", "views", "components", "ui")
+	if err := os.MkdirAll(uiDir, 0755); err != nil {
+		t.Fatalf("failed to create ui dir: %v", err)
+	}
+
+	_ = os.WriteFile(filepath.Join(uiDir, "button.templ"), []byte(""), 0644)
+	_ = os.WriteFile(filepath.Join(uiDir, "card.templ"), []byte(""), 0644)
+	_ = os.WriteFile(filepath.Join(uiDir, "README.md"), []byte(""), 0644)
+
+	installed := getInstalledComponents(tmpDir)
+
+	if !installed["button"] {
+		t.Error("expected button to be installed")
+	}
+	if !installed["card"] {
+		t.Error("expected card to be installed")
+	}
+	if installed["README"] {
+		t.Error("README.md should not be counted as installed component")
+	}
+}
+
+func TestGetInstalledComponents_NoDir(t *testing.T) {
+	installed := getInstalledComponents("/nonexistent/path")
+	if len(installed) != 0 {
+		t.Errorf("expected empty map for nonexistent dir, got %d entries", len(installed))
+	}
+}

--- a/internal/cli/commands/ui_upgrade.go
+++ b/internal/cli/commands/ui_upgrade.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/anomalousventures/tracks/internal/cli/interfaces"
+	"github.com/spf13/cobra"
+)
+
+// UIUpgradeCommand represents the 'ui upgrade' subcommand for updating templUI.
+type UIUpgradeCommand struct {
+	detector      interfaces.ProjectDetector
+	executor      interfaces.UIExecutor
+	newRenderer   RendererFactory
+	flushRenderer RendererFlusher
+}
+
+// NewUIUpgradeCommand creates a new instance of the 'ui upgrade' command with injected dependencies.
+func NewUIUpgradeCommand(
+	detector interfaces.ProjectDetector,
+	executor interfaces.UIExecutor,
+	newRenderer RendererFactory,
+	flushRenderer RendererFlusher,
+) *UIUpgradeCommand {
+	return &UIUpgradeCommand{
+		detector:      detector,
+		executor:      executor,
+		newRenderer:   newRenderer,
+		flushRenderer: flushRenderer,
+	}
+}
+
+// Command returns the cobra.Command for the 'ui upgrade' subcommand.
+func (c *UIUpgradeCommand) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade[@<ref>]",
+		Short: "Upgrade templUI to the latest or specified version",
+		Long: `Upgrade the templUI tool to a newer version.
+
+Without a version specified, upgrades to the latest available version.
+Use the @ref syntax to upgrade to a specific version.`,
+		Example: `  # Upgrade to latest version
+  tracks ui upgrade
+
+  # Upgrade to a specific version
+  tracks ui upgrade@v0.2.0`,
+		RunE: c.runE,
+	}
+
+	return cmd
+}
+
+func (c *UIUpgradeCommand) runE(cmd *cobra.Command, args []string) error {
+	r := c.newRenderer(cmd)
+	ctx := cmd.Context()
+	defer c.flushRenderer(cmd, r)
+
+	project, projectDir, err := c.detector.Detect(ctx, ".")
+	if err != nil {
+		r.Section(interfaces.Section{
+			Body: fmt.Sprintf("Error: %v", err),
+		})
+		return nil
+	}
+	if project == nil {
+		r.Section(interfaces.Section{
+			Body: "Error: not in a Tracks project (no .tracks.yaml found)",
+		})
+		return nil
+	}
+
+	ref := parseRefFromUse(cmd.Use, cmd.CalledAs())
+
+	r.Title("Upgrading templUI")
+
+	if err := c.executor.Upgrade(ctx, projectDir, ref); err != nil {
+		r.Section(interfaces.Section{
+			Body: fmt.Sprintf("Error: %v", err),
+		})
+		return nil
+	}
+
+	version, err := c.executor.Version(ctx, projectDir)
+	if err != nil {
+		r.Section(interfaces.Section{
+			Body: "Upgrade completed successfully",
+		})
+		return nil
+	}
+
+	targetMsg := "latest"
+	if ref != "" {
+		targetMsg = ref
+	}
+
+	r.Section(interfaces.Section{
+		Body: fmt.Sprintf("Successfully upgraded templUI to %s (version: %s)", targetMsg, version),
+	})
+
+	return nil
+}

--- a/internal/cli/commands/ui_upgrade_test.go
+++ b/internal/cli/commands/ui_upgrade_test.go
@@ -1,0 +1,228 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/cli/interfaces"
+	"github.com/anomalousventures/tracks/tests/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupUIUpgradeTestCommand(t *testing.T) (*cobra.Command, *mocks.MockUIExecutor, *mocks.MockProjectDetector, *mocks.MockRenderer) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	factory := func(*cobra.Command) interfaces.Renderer {
+		return mockRenderer
+	}
+	flusher := func(*cobra.Command, interfaces.Renderer) {
+		mockRenderer.Flush()
+	}
+
+	cmd := NewUIUpgradeCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	return cobraCmd, mockExecutor, mockDetector, mockRenderer
+}
+
+func TestUIUpgradeCommand_Command(t *testing.T) {
+	cobraCmd, _, _, _ := setupUIUpgradeTestCommand(t)
+
+	if cobraCmd == nil {
+		t.Fatal("Command() returned nil")
+	}
+
+	if !strings.HasPrefix(cobraCmd.Use, "upgrade") {
+		t.Errorf("expected Use to start with 'upgrade', got %q", cobraCmd.Use)
+	}
+
+	if cobraCmd.Short == "" {
+		t.Error("Short description is empty")
+	}
+
+	if cobraCmd.Long == "" {
+		t.Error("Long description is empty")
+	}
+
+	if cobraCmd.Example == "" {
+		t.Error("Example is empty")
+	}
+}
+
+func TestUIUpgradeCommand_Run_NotInProject(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(nil, "", nil).Once()
+
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "not in a Tracks project")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIUpgradeCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockDetector.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIUpgradeCommand_Run_Success(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("Upgrade", mock.Anything, "/tmp/testapp", "").
+		Return(nil).Once()
+	mockExecutor.On("Version", mock.Anything, "/tmp/testapp").
+		Return("v0.2.0", nil).Once()
+
+	mockRenderer.On("Title", "Upgrading templUI").Once()
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Successfully upgraded") &&
+			strings.Contains(s.Body, "latest") &&
+			strings.Contains(s.Body, "v0.2.0")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIUpgradeCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+	mockDetector.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIUpgradeCommand_Run_ExecutorError(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("Upgrade", mock.Anything, "/tmp/testapp", "").
+		Return(errors.New("upgrade failed")).Once()
+
+	mockRenderer.On("Title", mock.Anything).Once()
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Error:") && strings.Contains(s.Body, "upgrade failed")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIUpgradeCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}
+
+func TestUIUpgradeCommand_Run_VersionError(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	project := &interfaces.TracksProject{Name: "testapp"}
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(project, "/tmp/testapp", nil).Once()
+
+	mockExecutor.On("Upgrade", mock.Anything, "/tmp/testapp", "").
+		Return(nil).Once()
+	mockExecutor.On("Version", mock.Anything, "/tmp/testapp").
+		Return("", errors.New("version check failed")).Once()
+
+	mockRenderer.On("Title", mock.Anything).Once()
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Upgrade completed successfully")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIUpgradeCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockExecutor.AssertExpectations(t)
+}
+
+func TestUIUpgradeCommand_Run_DetectorError(t *testing.T) {
+	mockExecutor := mocks.NewMockUIExecutor(t)
+	mockDetector := mocks.NewMockProjectDetector(t)
+	mockRenderer := mocks.NewMockRenderer(t)
+
+	mockDetector.On("Detect", mock.Anything, ".").
+		Return(nil, "", errors.New("failed to detect project")).Once()
+
+	mockRenderer.On("Section", mock.MatchedBy(func(s interfaces.Section) bool {
+		return strings.Contains(s.Body, "Error:") && strings.Contains(s.Body, "failed to detect project")
+	})).Once()
+	mockRenderer.On("Flush").Return(nil).Once()
+
+	factory := func(*cobra.Command) interfaces.Renderer { return mockRenderer }
+	flusher := func(*cobra.Command, interfaces.Renderer) { mockRenderer.Flush() }
+
+	cmd := NewUIUpgradeCommand(mockDetector, mockExecutor, factory, flusher)
+	cobraCmd := cmd.Command()
+	cobraCmd.SetOut(new(bytes.Buffer))
+	cobraCmd.SetErr(new(bytes.Buffer))
+
+	err := cobraCmd.Execute()
+	if err != nil {
+		t.Fatalf("execution failed: %v", err)
+	}
+
+	mockDetector.AssertExpectations(t)
+	mockRenderer.AssertExpectations(t)
+}

--- a/internal/cli/interfaces/ui_executor.go
+++ b/internal/cli/interfaces/ui_executor.go
@@ -11,14 +11,17 @@ type UIExecutor interface {
 	Version(ctx context.Context, projectDir string) (string, error)
 
 	// Add installs one or more components into the project.
+	// If ref is non-empty, uses that version (e.g., "v0.1.0").
 	// If force is true, overwrites existing components.
-	Add(ctx context.Context, projectDir string, components []string, force bool) error
+	Add(ctx context.Context, projectDir, ref string, components []string, force bool) error
 
 	// List returns available components from the templUI registry.
-	List(ctx context.Context, projectDir string) ([]UIComponent, error)
+	// If ref is non-empty, lists components from that version.
+	List(ctx context.Context, projectDir, ref string) ([]UIComponent, error)
 
-	// Upgrade updates installed components to latest versions.
-	Upgrade(ctx context.Context, projectDir string) error
+	// Upgrade updates the templUI tool.
+	// If ref is non-empty, upgrades to that version; otherwise upgrades to latest.
+	Upgrade(ctx context.Context, projectDir, ref string) error
 
 	// IsAvailable checks if templui tool is installed and accessible.
 	IsAvailable(ctx context.Context, projectDir string) bool

--- a/internal/templui/executor.go
+++ b/internal/templui/executor.go
@@ -36,14 +36,19 @@ func (e *executor) Version(ctx context.Context, projectDir string) (string, erro
 	return strings.TrimSpace(string(output)), nil
 }
 
-func (e *executor) Add(ctx context.Context, projectDir string, components []string, force bool) error {
+func (e *executor) Add(ctx context.Context, projectDir, ref string, components []string, force bool) error {
 	logger := zerolog.Ctx(ctx)
 
 	if len(components) == 0 {
 		return fmt.Errorf("at least one component name required")
 	}
 
-	args := []string{"tool", "templui", "add"}
+	toolName := "templui"
+	if ref != "" {
+		toolName = fmt.Sprintf("templui@%s", ref)
+	}
+
+	args := []string{"tool", toolName, "add"}
 	if force {
 		args = append(args, "-f")
 	}
@@ -66,17 +71,22 @@ func (e *executor) Add(ctx context.Context, projectDir string, components []stri
 	return nil
 }
 
-func (e *executor) List(ctx context.Context, projectDir string) ([]interfaces.UIComponent, error) {
+func (e *executor) List(ctx context.Context, projectDir, ref string) ([]interfaces.UIComponent, error) {
 	logger := zerolog.Ctx(ctx)
 
-	cmd := exec.CommandContext(ctx, "go", "tool", "templui", "list")
+	toolName := "templui"
+	if ref != "" {
+		toolName = fmt.Sprintf("templui@%s", ref)
+	}
+
+	cmd := exec.CommandContext(ctx, "go", "tool", toolName, "list")
 	cmd.Dir = projectDir
 
 	output, err := cmd.Output()
 	if err != nil {
 		logger.Error().
 			Err(err).
-			Str("command", "go tool templui list").
+			Str("command", fmt.Sprintf("go tool %s list", toolName)).
 			Str("dir", projectDir).
 			Msg("failed to list components")
 		return nil, fmt.Errorf("failed to list components: %w", err)
@@ -85,21 +95,26 @@ func (e *executor) List(ctx context.Context, projectDir string) ([]interfaces.UI
 	return parseComponentList(string(output)), nil
 }
 
-func (e *executor) Upgrade(ctx context.Context, projectDir string) error {
+func (e *executor) Upgrade(ctx context.Context, projectDir, ref string) error {
 	logger := zerolog.Ctx(ctx)
 
-	cmd := exec.CommandContext(ctx, "go", "tool", "templui", "upgrade")
+	toolName := "templui"
+	if ref != "" {
+		toolName = fmt.Sprintf("templui@%s", ref)
+	}
+
+	cmd := exec.CommandContext(ctx, "go", "tool", toolName, "upgrade")
 	cmd.Dir = projectDir
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		logger.Error().
 			Err(err).
-			Str("command", "go tool templui upgrade").
+			Str("command", fmt.Sprintf("go tool %s upgrade", toolName)).
 			Str("output", string(output)).
 			Str("dir", projectDir).
-			Msg("failed to upgrade components")
-		return fmt.Errorf("failed to upgrade components: %w", err)
+			Msg("failed to upgrade templui")
+		return fmt.Errorf("failed to upgrade templui: %w", err)
 	}
 
 	return nil

--- a/internal/templui/executor_test.go
+++ b/internal/templui/executor_test.go
@@ -84,7 +84,7 @@ func TestParseComponentList(t *testing.T) {
 func TestExecutor_Add_EmptyComponents(t *testing.T) {
 	executor := NewExecutor()
 
-	err := executor.Add(t.Context(), ".", []string{}, false)
+	err := executor.Add(t.Context(), ".", "", []string{}, false)
 	if err == nil {
 		t.Fatal("expected error for empty components, got nil")
 	}

--- a/tests/mocks/mock_UIExecutor.go
+++ b/tests/mocks/mock_UIExecutor.go
@@ -39,16 +39,16 @@ func (_m *MockUIExecutor) EXPECT() *MockUIExecutor_Expecter {
 }
 
 // Add provides a mock function for the type MockUIExecutor
-func (_mock *MockUIExecutor) Add(ctx context.Context, projectDir string, components []string, force bool) error {
-	ret := _mock.Called(ctx, projectDir, components, force)
+func (_mock *MockUIExecutor) Add(ctx context.Context, projectDir string, ref string, components []string, force bool) error {
+	ret := _mock.Called(ctx, projectDir, ref, components, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Add")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, bool) error); ok {
-		r0 = returnFunc(ctx, projectDir, components, force)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, []string, bool) error); ok {
+		r0 = returnFunc(ctx, projectDir, ref, components, force)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -63,13 +63,14 @@ type MockUIExecutor_Add_Call struct {
 // Add is a helper method to define mock.On call
 //   - ctx context.Context
 //   - projectDir string
+//   - ref string
 //   - components []string
 //   - force bool
-func (_e *MockUIExecutor_Expecter) Add(ctx interface{}, projectDir interface{}, components interface{}, force interface{}) *MockUIExecutor_Add_Call {
-	return &MockUIExecutor_Add_Call{Call: _e.mock.On("Add", ctx, projectDir, components, force)}
+func (_e *MockUIExecutor_Expecter) Add(ctx interface{}, projectDir interface{}, ref interface{}, components interface{}, force interface{}) *MockUIExecutor_Add_Call {
+	return &MockUIExecutor_Add_Call{Call: _e.mock.On("Add", ctx, projectDir, ref, components, force)}
 }
 
-func (_c *MockUIExecutor_Add_Call) Run(run func(ctx context.Context, projectDir string, components []string, force bool)) *MockUIExecutor_Add_Call {
+func (_c *MockUIExecutor_Add_Call) Run(run func(ctx context.Context, projectDir string, ref string, components []string, force bool)) *MockUIExecutor_Add_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -79,19 +80,24 @@ func (_c *MockUIExecutor_Add_Call) Run(run func(ctx context.Context, projectDir 
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []string
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].([]string)
+			arg2 = args[2].(string)
 		}
-		var arg3 bool
+		var arg3 []string
 		if args[3] != nil {
-			arg3 = args[3].(bool)
+			arg3 = args[3].([]string)
+		}
+		var arg4 bool
+		if args[4] != nil {
+			arg4 = args[4].(bool)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -102,7 +108,7 @@ func (_c *MockUIExecutor_Add_Call) Return(err error) *MockUIExecutor_Add_Call {
 	return _c
 }
 
-func (_c *MockUIExecutor_Add_Call) RunAndReturn(run func(ctx context.Context, projectDir string, components []string, force bool) error) *MockUIExecutor_Add_Call {
+func (_c *MockUIExecutor_Add_Call) RunAndReturn(run func(ctx context.Context, projectDir string, ref string, components []string, force bool) error) *MockUIExecutor_Add_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -165,8 +171,8 @@ func (_c *MockUIExecutor_IsAvailable_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // List provides a mock function for the type MockUIExecutor
-func (_mock *MockUIExecutor) List(ctx context.Context, projectDir string) ([]interfaces.UIComponent, error) {
-	ret := _mock.Called(ctx, projectDir)
+func (_mock *MockUIExecutor) List(ctx context.Context, projectDir string, ref string) ([]interfaces.UIComponent, error) {
+	ret := _mock.Called(ctx, projectDir, ref)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -174,18 +180,18 @@ func (_mock *MockUIExecutor) List(ctx context.Context, projectDir string) ([]int
 
 	var r0 []interfaces.UIComponent
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]interfaces.UIComponent, error)); ok {
-		return returnFunc(ctx, projectDir)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]interfaces.UIComponent, error)); ok {
+		return returnFunc(ctx, projectDir, ref)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []interfaces.UIComponent); ok {
-		r0 = returnFunc(ctx, projectDir)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []interfaces.UIComponent); ok {
+		r0 = returnFunc(ctx, projectDir, ref)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]interfaces.UIComponent)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, projectDir)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, projectDir, ref)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -200,11 +206,12 @@ type MockUIExecutor_List_Call struct {
 // List is a helper method to define mock.On call
 //   - ctx context.Context
 //   - projectDir string
-func (_e *MockUIExecutor_Expecter) List(ctx interface{}, projectDir interface{}) *MockUIExecutor_List_Call {
-	return &MockUIExecutor_List_Call{Call: _e.mock.On("List", ctx, projectDir)}
+//   - ref string
+func (_e *MockUIExecutor_Expecter) List(ctx interface{}, projectDir interface{}, ref interface{}) *MockUIExecutor_List_Call {
+	return &MockUIExecutor_List_Call{Call: _e.mock.On("List", ctx, projectDir, ref)}
 }
 
-func (_c *MockUIExecutor_List_Call) Run(run func(ctx context.Context, projectDir string)) *MockUIExecutor_List_Call {
+func (_c *MockUIExecutor_List_Call) Run(run func(ctx context.Context, projectDir string, ref string)) *MockUIExecutor_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -214,9 +221,14 @@ func (_c *MockUIExecutor_List_Call) Run(run func(ctx context.Context, projectDir
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -227,22 +239,22 @@ func (_c *MockUIExecutor_List_Call) Return(uIComponents []interfaces.UIComponent
 	return _c
 }
 
-func (_c *MockUIExecutor_List_Call) RunAndReturn(run func(ctx context.Context, projectDir string) ([]interfaces.UIComponent, error)) *MockUIExecutor_List_Call {
+func (_c *MockUIExecutor_List_Call) RunAndReturn(run func(ctx context.Context, projectDir string, ref string) ([]interfaces.UIComponent, error)) *MockUIExecutor_List_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Upgrade provides a mock function for the type MockUIExecutor
-func (_mock *MockUIExecutor) Upgrade(ctx context.Context, projectDir string) error {
-	ret := _mock.Called(ctx, projectDir)
+func (_mock *MockUIExecutor) Upgrade(ctx context.Context, projectDir string, ref string) error {
+	ret := _mock.Called(ctx, projectDir, ref)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Upgrade")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, projectDir)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, projectDir, ref)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -257,11 +269,12 @@ type MockUIExecutor_Upgrade_Call struct {
 // Upgrade is a helper method to define mock.On call
 //   - ctx context.Context
 //   - projectDir string
-func (_e *MockUIExecutor_Expecter) Upgrade(ctx interface{}, projectDir interface{}) *MockUIExecutor_Upgrade_Call {
-	return &MockUIExecutor_Upgrade_Call{Call: _e.mock.On("Upgrade", ctx, projectDir)}
+//   - ref string
+func (_e *MockUIExecutor_Expecter) Upgrade(ctx interface{}, projectDir interface{}, ref interface{}) *MockUIExecutor_Upgrade_Call {
+	return &MockUIExecutor_Upgrade_Call{Call: _e.mock.On("Upgrade", ctx, projectDir, ref)}
 }
 
-func (_c *MockUIExecutor_Upgrade_Call) Run(run func(ctx context.Context, projectDir string)) *MockUIExecutor_Upgrade_Call {
+func (_c *MockUIExecutor_Upgrade_Call) Run(run func(ctx context.Context, projectDir string, ref string)) *MockUIExecutor_Upgrade_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -271,9 +284,14 @@ func (_c *MockUIExecutor_Upgrade_Call) Run(run func(ctx context.Context, project
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -284,7 +302,7 @@ func (_c *MockUIExecutor_Upgrade_Call) Return(err error) *MockUIExecutor_Upgrade
 	return _c
 }
 
-func (_c *MockUIExecutor_Upgrade_Call) RunAndReturn(run func(ctx context.Context, projectDir string) error) *MockUIExecutor_Upgrade_Call {
+func (_c *MockUIExecutor_Upgrade_Call) RunAndReturn(run func(ctx context.Context, projectDir string, ref string) error) *MockUIExecutor_Upgrade_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
- Implement `tracks ui add` command to install templUI components with automatic script injection into base.templ
- Implement `tracks ui list` command to display available/installed components in table format  
- Implement `tracks ui upgrade` command to update templUI to latest or specific version
- Support `@ref` version syntax for all subcommands (e.g., `tracks ui add@v0.1.0 button`)
- Fix `lint-mocks` Makefile target to use `git diff` instead of `git status` for correct pre-commit hook behavior

## Test plan
- [x] Unit tests pass for all new commands
- [x] Integration tests pass
- [x] Pre-commit hook validation passes
- [ ] Manual testing: `tracks ui add button` in a generated project
- [ ] Manual testing: `tracks ui list` shows available components
- [ ] Manual testing: `tracks ui upgrade` updates templUI

Fixes #477, Fixes #478, Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)