### PR TITLE
feat: add initial schema migrations for SQLite and PostgreSQL (#523)

### DIFF
--- a/internal/generator/template/data.go
+++ b/internal/generator/template/data.go
@@ -30,4 +30,9 @@ type TemplateData struct {
 
 	// SecretKey is a cryptographically secure random key for session management.
 	SecretKey string
+
+	// MigrationTimestamp is the timestamp prefix for initial migration files.
+	// Format: YYYYMMDDHHMMSS (e.g., "20251130143022")
+	// Used to generate unique, sortable migration filenames.
+	MigrationTimestamp string
 }

--- a/internal/generator/template/migration_sql_test.go
+++ b/internal/generator/template/migration_sql_test.go
@@ -1,0 +1,122 @@
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/templates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderMigrationTemplate(t *testing.T, driver string) string {
+	t.Helper()
+	renderer := NewRenderer(templates.FS)
+
+	templatePath := "internal/db/migrations/sqlite/initial_schema.sql.tmpl"
+	if driver == "postgres" {
+		templatePath = "internal/db/migrations/postgres/initial_schema.sql.tmpl"
+	}
+
+	data := TemplateData{
+		ModuleName:         "github.com/test/app",
+		MigrationTimestamp: "20251130143022",
+	}
+
+	result, err := renderer.Render(templatePath, data)
+	require.NoError(t, err)
+	return result
+}
+
+func TestMigrationSQLTemplateRenders(t *testing.T) {
+	tests := []struct {
+		name   string
+		driver string
+	}{
+		{"sqlite", "sqlite"},
+		{"postgres", "postgres"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.driver, func(t *testing.T) {
+			result := renderMigrationTemplate(t, tt.driver)
+			assert.NotEmpty(t, result, "template should render")
+		})
+	}
+}
+
+func TestMigrationSQLGooseAnnotations(t *testing.T) {
+	tests := []string{"sqlite", "postgres"}
+
+	for _, driver := range tests {
+		t.Run(driver, func(t *testing.T) {
+			result := renderMigrationTemplate(t, driver)
+
+			assert.Contains(t, result, "-- +goose Up", "should have +goose Up annotation")
+			assert.Contains(t, result, "-- +goose Down", "should have +goose Down annotation")
+			assert.Contains(t, result, "-- +goose StatementBegin", "should have +goose StatementBegin")
+			assert.Contains(t, result, "-- +goose StatementEnd", "should have +goose StatementEnd")
+		})
+	}
+}
+
+func TestMigrationSQLReversible(t *testing.T) {
+	tests := []string{"sqlite", "postgres"}
+
+	for _, driver := range tests {
+		t.Run(driver, func(t *testing.T) {
+			result := renderMigrationTemplate(t, driver)
+
+			upIdx := strings.Index(result, "-- +goose Up")
+			downIdx := strings.Index(result, "-- +goose Down")
+
+			require.NotEqual(t, -1, upIdx, "should have Up section")
+			require.NotEqual(t, -1, downIdx, "should have Down section")
+			assert.Less(t, upIdx, downIdx, "Up section should come before Down section")
+		})
+	}
+}
+
+func TestMigrationSQLSQLitePatterns(t *testing.T) {
+	result := renderMigrationTemplate(t, "sqlite")
+
+	assert.Contains(t, result, "AFTER UPDATE", "should document AFTER UPDATE trigger pattern")
+	assert.Contains(t, result, "CURRENT_TIMESTAMP", "should use CURRENT_TIMESTAMP")
+	assert.Contains(t, result, "TEXT PRIMARY KEY", "should document TEXT for UUIDv7")
+}
+
+func TestMigrationSQLPostgresPatterns(t *testing.T) {
+	result := renderMigrationTemplate(t, "postgres")
+
+	assert.Contains(t, result, "update_updated_at_column()", "should create trigger function")
+	assert.Contains(t, result, "RETURNS TRIGGER", "should return TRIGGER type")
+	assert.Contains(t, result, "BEFORE UPDATE", "should document BEFORE UPDATE trigger pattern")
+	assert.Contains(t, result, "TIMESTAMPTZ", "should use TIMESTAMPTZ")
+	assert.Contains(t, result, "NOW()", "should use NOW()")
+	assert.Contains(t, result, "plpgsql", "should use plpgsql language")
+}
+
+func TestMigrationSQLPostgresDownDropsFunction(t *testing.T) {
+	result := renderMigrationTemplate(t, "postgres")
+
+	downIdx := strings.Index(result, "-- +goose Down")
+	require.NotEqual(t, -1, downIdx)
+
+	downSection := result[downIdx:]
+	assert.Contains(t, downSection, "DROP FUNCTION", "Down should drop the function")
+	assert.Contains(t, downSection, "update_updated_at_column", "Down should reference the function name")
+}
+
+func TestMigrationSQLSQLiteNoPostgresPatterns(t *testing.T) {
+	result := renderMigrationTemplate(t, "sqlite")
+
+	assert.NotContains(t, result, "TIMESTAMPTZ", "should not use PostgreSQL TIMESTAMPTZ")
+	assert.NotContains(t, result, "plpgsql", "should not use plpgsql")
+	assert.NotContains(t, result, "EXECUTE FUNCTION", "should not use PostgreSQL trigger syntax")
+}
+
+func TestMigrationSQLPostgresNoSQLitePatterns(t *testing.T) {
+	result := renderMigrationTemplate(t, "postgres")
+
+	assert.NotContains(t, result, "AFTER UPDATE ON", "should not use SQLite AFTER UPDATE trigger pattern")
+}

--- a/internal/templates/project/internal/db/migrations/postgres/initial_schema.sql.tmpl
+++ b/internal/templates/project/internal/db/migrations/postgres/initial_schema.sql.tmpl
@@ -1,0 +1,38 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Initial schema for PostgreSQL
+--
+-- Conventions established:
+-- - UUIDv7 TEXT columns for primary keys
+-- - TIMESTAMPTZ columns with NOW() defaults
+-- - BEFORE UPDATE triggers for updated_at columns
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Usage: When creating tables with updated_at, add:
+--
+-- CREATE TRIGGER trg_<tablename>_updated_at
+--     BEFORE UPDATE ON <tablename>
+--     FOR EACH ROW
+--     EXECUTE FUNCTION update_updated_at_column();
+--
+-- Example table:
+--
+-- CREATE TABLE example (
+--     id TEXT PRIMARY KEY,
+--     name TEXT NOT NULL,
+--     created_at TIMESTAMPTZ DEFAULT NOW(),
+--     updated_at TIMESTAMPTZ DEFAULT NOW()
+-- );
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP FUNCTION IF EXISTS update_updated_at_column();
+-- +goose StatementEnd

--- a/internal/templates/project/internal/db/migrations/postgres/placeholder.sql.tmpl
+++ b/internal/templates/project/internal/db/migrations/postgres/placeholder.sql.tmpl
@@ -1,7 +1,0 @@
--- +goose Up
--- Placeholder migration for embed directive.
--- This file will be replaced by initial schema in Issue #523.
--- Do not add actual schema here.
-
--- +goose Down
--- No-op placeholder

--- a/internal/templates/project/internal/db/migrations/sqlite/initial_schema.sql.tmpl
+++ b/internal/templates/project/internal/db/migrations/sqlite/initial_schema.sql.tmpl
@@ -1,0 +1,34 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Initial schema for SQLite/go-libsql
+--
+-- Conventions established:
+-- - UUIDv7 TEXT columns for primary keys
+-- - TIMESTAMP columns with CURRENT_TIMESTAMP defaults
+-- - AFTER UPDATE triggers for updated_at columns
+--
+-- Trigger pattern (create when adding tables with updated_at):
+--
+-- CREATE TRIGGER trg_<tablename>_updated_at
+-- AFTER UPDATE ON <tablename>
+-- FOR EACH ROW
+-- BEGIN
+--     UPDATE <tablename> SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+-- END;
+--
+-- Example table:
+--
+-- CREATE TABLE example (
+--     id TEXT PRIMARY KEY,
+--     name TEXT NOT NULL,
+--     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+--     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+-- );
+
+SELECT 1;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 1;
+-- +goose StatementEnd

--- a/internal/templates/project/internal/db/migrations/sqlite/placeholder.sql.tmpl
+++ b/internal/templates/project/internal/db/migrations/sqlite/placeholder.sql.tmpl
@@ -1,7 +1,0 @@
--- +goose Up
--- Placeholder migration for embed directive.
--- This file will be replaced by initial schema in Issue #523.
--- Do not add actual schema here.
-
--- +goose Down
--- No-op placeholder

--- a/tests/integration/migration_test.go
+++ b/tests/integration/migration_test.go
@@ -1,0 +1,247 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/anomalousventures/tracks/internal/generator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrationFilesGenerated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		name           string
+		databaseDriver string
+		migrationDir   string
+	}{
+		{"go-libsql", "go-libsql", "sqlite"},
+		{"sqlite3", "sqlite3", "sqlite"},
+		{"postgres", "postgres", "postgres"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			projectName := "testapp"
+
+			cfg := generator.ProjectConfig{
+				ProjectName:    projectName,
+				ModulePath:     "github.com/test/app",
+				DatabaseDriver: tt.databaseDriver,
+				EnvPrefix:      "APP",
+				InitGit:        false,
+				OutputPath:     tmpDir,
+			}
+
+			gen := generator.NewProjectGenerator()
+			ctx := context.Background()
+
+			err := gen.Generate(ctx, cfg)
+			require.NoError(t, err, "generation should succeed")
+
+			projectRoot := filepath.Join(tmpDir, projectName)
+			migrationDir := filepath.Join(projectRoot, "internal", "db", "migrations", tt.migrationDir)
+
+			entries, err := os.ReadDir(migrationDir)
+			require.NoError(t, err, "should be able to read migration directory")
+
+			var migrationFile string
+			timestampPattern := regexp.MustCompile(`^\d{14}_initial_schema\.sql$`)
+
+			for _, entry := range entries {
+				if timestampPattern.MatchString(entry.Name()) {
+					migrationFile = entry.Name()
+					break
+				}
+			}
+
+			require.NotEmpty(t, migrationFile, "should find timestamped initial schema migration")
+
+			content, err := os.ReadFile(filepath.Join(migrationDir, migrationFile))
+			require.NoError(t, err)
+
+			assert.Contains(t, string(content), "-- +goose Up", "migration should have Up section")
+			assert.Contains(t, string(content), "-- +goose Down", "migration should have Down section")
+			assert.Contains(t, string(content), "-- +goose StatementBegin", "migration should have StatementBegin")
+			assert.Contains(t, string(content), "-- +goose StatementEnd", "migration should have StatementEnd")
+		})
+	}
+}
+
+func TestMigrationDriverSpecificContent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		driver         string
+		migrationDir   string
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{
+			driver:       "sqlite3",
+			migrationDir: "sqlite",
+			mustContain:  []string{"AFTER UPDATE", "CURRENT_TIMESTAMP"},
+			mustNotContain: []string{"TIMESTAMPTZ", "plpgsql"},
+		},
+		{
+			driver:       "postgres",
+			migrationDir: "postgres",
+			mustContain:  []string{"TIMESTAMPTZ", "BEFORE UPDATE", "plpgsql", "update_updated_at_column"},
+			mustNotContain: []string{"AFTER UPDATE ON"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.driver, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			projectName := "testapp"
+
+			cfg := generator.ProjectConfig{
+				ProjectName:    projectName,
+				ModulePath:     "github.com/test/app",
+				DatabaseDriver: tt.driver,
+				EnvPrefix:      "APP",
+				InitGit:        false,
+				OutputPath:     tmpDir,
+			}
+
+			gen := generator.NewProjectGenerator()
+			err := gen.Generate(context.Background(), cfg)
+			require.NoError(t, err)
+
+			migrationDir := filepath.Join(tmpDir, projectName, "internal", "db", "migrations", tt.migrationDir)
+			entries, err := os.ReadDir(migrationDir)
+			require.NoError(t, err)
+
+			timestampPattern := regexp.MustCompile(`^\d{14}_initial_schema\.sql$`)
+			var content []byte
+
+			for _, entry := range entries {
+				if timestampPattern.MatchString(entry.Name()) {
+					content, err = os.ReadFile(filepath.Join(migrationDir, entry.Name()))
+					require.NoError(t, err)
+					break
+				}
+			}
+
+			require.NotEmpty(t, content, "should find migration file")
+
+			for _, expected := range tt.mustContain {
+				assert.Contains(t, string(content), expected, "should contain %s", expected)
+			}
+
+			for _, excluded := range tt.mustNotContain {
+				assert.NotContains(t, string(content), excluded, "should not contain %s", excluded)
+			}
+		})
+	}
+}
+
+func TestMigrationBothDirectoriesCreated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	projectName := "testapp"
+
+	cfg := generator.ProjectConfig{
+		ProjectName:    projectName,
+		ModulePath:     "github.com/test/app",
+		DatabaseDriver: "sqlite3",
+		EnvPrefix:      "APP",
+		InitGit:        false,
+		OutputPath:     tmpDir,
+	}
+
+	gen := generator.NewProjectGenerator()
+	err := gen.Generate(context.Background(), cfg)
+	require.NoError(t, err)
+
+	projectRoot := filepath.Join(tmpDir, projectName)
+	timestampPattern := regexp.MustCompile(`^\d{14}_initial_schema\.sql$`)
+
+	for _, dir := range []string{"sqlite", "postgres"} {
+		migrationDir := filepath.Join(projectRoot, "internal", "db", "migrations", dir)
+
+		stat, err := os.Stat(migrationDir)
+		require.NoError(t, err, "migration directory %s should exist", dir)
+		assert.True(t, stat.IsDir(), "%s should be a directory", dir)
+
+		entries, err := os.ReadDir(migrationDir)
+		require.NoError(t, err)
+
+		found := false
+		for _, entry := range entries {
+			if timestampPattern.MatchString(entry.Name()) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "should find timestamped migration in %s directory", dir)
+	}
+}
+
+func TestMigrationTimestampFormat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	projectName := "testapp"
+
+	cfg := generator.ProjectConfig{
+		ProjectName:    projectName,
+		ModulePath:     "github.com/test/app",
+		DatabaseDriver: "sqlite3",
+		EnvPrefix:      "APP",
+		InitGit:        false,
+		OutputPath:     tmpDir,
+	}
+
+	gen := generator.NewProjectGenerator()
+	err := gen.Generate(context.Background(), cfg)
+	require.NoError(t, err)
+
+	migrationDir := filepath.Join(tmpDir, projectName, "internal", "db", "migrations", "sqlite")
+	entries, err := os.ReadDir(migrationDir)
+	require.NoError(t, err)
+
+	timestampPattern := regexp.MustCompile(`^(\d{14})_initial_schema\.sql$`)
+
+	var timestamp string
+	for _, entry := range entries {
+		matches := timestampPattern.FindStringSubmatch(entry.Name())
+		if len(matches) > 1 {
+			timestamp = matches[1]
+			break
+		}
+	}
+
+	require.NotEmpty(t, timestamp, "should extract timestamp from filename")
+	assert.Len(t, timestamp, 14, "timestamp should be 14 digits (YYYYMMDDHHMMSS)")
+
+	year := timestamp[0:4]
+	month := timestamp[4:6]
+	day := timestamp[6:8]
+	hour := timestamp[8:10]
+	minute := timestamp[10:12]
+	second := timestamp[12:14]
+
+	assert.Regexp(t, `^20\d{2}$`, year, "year should be valid (20XX)")
+	assert.Regexp(t, `^(0[1-9]|1[0-2])$`, month, "month should be 01-12")
+	assert.Regexp(t, `^(0[1-9]|[12]\d|3[01])$`, day, "day should be 01-31")
+	assert.Regexp(t, `^([01]\d|2[0-3])$`, hour, "hour should be 00-23")
+	assert.Regexp(t, `^[0-5]\d$`, minute, "minute should be 00-59")
+	assert.Regexp(t, `^[0-5]\d$`, second, "second should be 00-59")
+}


### PR DESCRIPTION
## What

Replace placeholder migration templates with driver-specific initial schema migrations that establish reusable patterns for `updated_at` triggers.

Closes #523

## Why

Issue #522 created the migration infrastructure with placeholder files. This PR replaces those placeholders with actual initial schema migrations that:
- Establish database conventions (UUIDv7 TEXT columns, timestamp patterns)
- Provide PostgreSQL with a reusable `update_updated_at_column()` trigger function
- Document SQLite's AFTER UPDATE trigger pattern for future table creation
- Generate timestamped migration filenames for proper ordering

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)
- [x] New template tests in `internal/generator/template/migration_sql_test.go`
- [x] New integration tests in `tests/integration/migration_test.go`
- [x] All 3 database drivers tested (go-libsql, sqlite3, postgres)

## Notes

- Migrations use "patterns-only" approach - no tables created
- PostgreSQL creates actual function; SQLite documents pattern in comments (triggers are table-specific)
- Both `sqlite/` and `postgres/` directories get migration files regardless of selected driver
- Migration filenames use dynamic timestamps (YYYYMMDDHHMMSS format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)