### PR TITLE
feat: add TEXT→string type override to sqlc config

### DIFF
--- a/internal/templates/project/sqlc.yaml.tmpl
+++ b/internal/templates/project/sqlc.yaml.tmpl
@@ -14,3 +14,7 @@ sql:
         emit_json_tags: true
         emit_interface: true
         emit_empty_slices: true
+        overrides:
+          - db_type: "TEXT"
+            go_type: "string"
+            nullable: false


### PR DESCRIPTION
## What

Audited sqlc.yaml.tmpl against PRD specs and added the missing TEXT→string type override.

## Why

The PRD (docs/prd/2_database_layer.md:343-346) specifies that TEXT columns should map to Go `string` instead of `sql.NullString`. This override was missing from the template.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)

## Notes

Most of the issue requirements were already implemented. The audit confirmed:
- ✅ Engine mapping (go-libsql/sqlite3 → sqlite, postgres → postgresql)
- ✅ Schema path uses driver-specific migrations directory
- ✅ emit_json_tags, emit_interface, emit_empty_slices configured
- ✅ 11 existing template tests

Only the TEXT→string override was missing.

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)