### PR TITLE
docs: add database documentation and CLI reference (#534)

### DIFF
--- a/internal/templates/project/.env.example.tmpl
+++ b/internal/templates/project/.env.example.tmpl
@@ -37,7 +37,8 @@
 {{.EnvPrefix}}_DATABASE_CONNECT_TIMEOUT=10s
 {{.EnvPrefix}}_DATABASE_MAX_OPEN_CONNS=25
 {{.EnvPrefix}}_DATABASE_MAX_IDLE_CONNS=5
-{{.EnvPrefix}}_DATABASE_CONN_MAX_LIFETIME=5m
+{{.EnvPrefix}}_DATABASE_CONN_MAX_LIFETIME=1h
+{{.EnvPrefix}}_DATABASE_CONN_MAX_IDLE_TIME=5m
 
 # Logging Configuration
 {{.EnvPrefix}}_LOGGING_LEVEL=info

--- a/website/docs/cli/commands.md
+++ b/website/docs/cli/commands.md
@@ -12,6 +12,15 @@ Quick reference for all Tracks CLI commands.
 
 Create a new Tracks application with production-ready structure and database support.
 
+### [tracks db](db.md)
+
+Manage database migrations. Subcommands:
+
+- `tracks db migrate` - Apply pending migrations
+- `tracks db rollback` - Roll back last migration
+- `tracks db status` - Show migration status
+- `tracks db reset` - Reset database (rollback all, reapply)
+
 ### [tracks version](version.md)
 
 Display version, commit, and build information.

--- a/website/docs/cli/db.md
+++ b/website/docs/cli/db.md
@@ -1,0 +1,125 @@
+# tracks db
+
+Manage database migrations for Tracks applications.
+
+## Usage
+
+```bash
+tracks db <command> [flags]
+```
+
+These commands must be run from within a Tracks project directory (where `.tracks.yaml` exists). They read database configuration from environment variables, typically loaded from your `.env` file.
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `migrate` | Apply pending migrations |
+| `rollback` | Roll back last migration |
+| `status` | Show migration status |
+| `reset` | Reset database |
+
+## tracks db migrate
+
+Apply all pending database migrations in order. Migrations are SQL files in `internal/db/migrations/` that define schema changes.
+
+```bash
+tracks db migrate [--dry-run]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview migrations without applying |
+
+Use `--dry-run` to see what would run before making changes:
+
+```bash
+tracks db migrate --dry-run
+```
+
+## tracks db rollback
+
+Roll back the most recently applied migration. Useful for undoing a migration during development or fixing issues.
+
+```bash
+tracks db rollback
+```
+
+## tracks db status
+
+Show which migrations have been applied and which are pending. Helpful for debugging migration issues or verifying deployment state.
+
+```bash
+tracks db status
+```
+
+## tracks db reset
+
+Reset the database by rolling back all migrations then reapplying them. This destroys all data - use with caution.
+
+```bash
+tracks db reset [--force]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Skip confirmation prompt |
+
+In CI or scripts, use `--force` to skip the interactive confirmation:
+
+```bash
+tracks db reset --force
+```
+
+## Supported Drivers
+
+| Driver | Status |
+|--------|--------|
+| `postgres` | Supported |
+| `sqlite3` | Use `make migrate-*` targets |
+| `go-libsql` | Use `make migrate-*` targets |
+
+For SQLite and go-libsql projects, use the generated Makefile targets instead:
+
+```bash
+make migrate-up
+make migrate-down
+make migrate-status
+```
+
+## Environment
+
+| Variable | Description |
+|----------|-------------|
+| `APP_DATABASE_URL` | Database connection string (required) |
+
+The command loads `.env` automatically, or you can set the variable directly:
+
+```bash
+APP_DATABASE_URL=postgres://localhost/myapp tracks db migrate
+```
+
+## Common Errors
+
+**Not in a project:** Run from your project root where `.tracks.yaml` exists.
+
+```text
+Error: not in a Tracks project directory (missing .tracks.yaml)
+```
+
+**Missing database URL:** Create a `.env` file or set the variable.
+
+```text
+Error: APP_DATABASE_URL environment variable is not set
+```
+
+**Connection failed:** Check that your database is running and the URL is correct.
+
+```text
+Error: failed to connect to database: connection refused
+```
+
+## See Also
+
+- [Database Setup](../guides/database-setup.md) - Configuration and drivers
+- [Migrations Guide](../guides/migrations.md) - Writing migration files

--- a/website/docs/cli/overview.mdx
+++ b/website/docs/cli/overview.mdx
@@ -26,8 +26,9 @@ See [Commands Reference](./commands.md) for available commands and flags.
 tracks --help
 
 # Command-specific help
-tracks version --help
 tracks new --help
+tracks db --help
+tracks db migrate --help
 
 # List all commands
 tracks help

--- a/website/docs/guides/database-setup.md
+++ b/website/docs/guides/database-setup.md
@@ -64,18 +64,18 @@ db.SetConnMaxIdleTime(cfg.ConnMaxIdleTime) // default: 5m
 db.SetConnMaxLifetime(cfg.ConnMaxLifetime) // default: 1h
 ```
 
-### SQLite
+### SQLite3
 
-Single connection with WAL mode for consistency:
+Single connection with WAL mode (enabled automatically):
 
 ```go
 db.SetMaxOpenConns(1)
 db.SetMaxIdleConns(1)
 ```
 
-```sql
-PRAGMA journal_mode=WAL
-```
+### go-libsql
+
+Connects via HTTP to Turso—connection pooling is managed server-side. Local instances use the same single-connection pattern as SQLite3 but without WAL mode (Turso handles durability).
 
 ## Local Development
 

--- a/website/docs/guides/database-setup.md
+++ b/website/docs/guides/database-setup.md
@@ -1,0 +1,118 @@
+# Database Setup
+
+Configure and connect your Tracks application to a database.
+
+## Supported Drivers
+
+| Driver | Best For | CGO Required |
+|--------|----------|--------------|
+| `postgres` | Production workloads, teams | No |
+| `sqlite3` | Development, single-server | Yes |
+| `go-libsql` | Edge deployment with Turso | Yes |
+
+```bash
+tracks new myapp --db postgres
+tracks new myapp --db sqlite3
+tracks new myapp --db go-libsql
+```
+
+## Configuration
+
+Database settings use environment variables with the `APP_` prefix.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `APP_DATABASE_URL` | string | varies | Connection string |
+| `APP_DATABASE_CONNECT_TIMEOUT` | duration | `10s` | Connection timeout |
+| `APP_DATABASE_MAX_OPEN_CONNS` | int | `25` | Max open connections (PostgreSQL) |
+| `APP_DATABASE_MAX_IDLE_CONNS` | int | `5` | Max idle connections (PostgreSQL) |
+| `APP_DATABASE_CONN_MAX_IDLE_TIME` | duration | `5m` | Max idle time |
+| `APP_DATABASE_CONN_MAX_LIFETIME` | duration | `1h` | Max lifetime |
+
+### Connection Strings
+
+**PostgreSQL:**
+
+```bash
+APP_DATABASE_URL=postgres://user:password@localhost:5432/myapp?sslmode=disable
+```
+
+**SQLite3:**
+
+```bash
+APP_DATABASE_URL=file:./data/myapp.db  # File-based
+APP_DATABASE_URL=:memory:               # In-memory
+```
+
+**go-libsql (Turso):**
+
+```bash
+APP_DATABASE_URL=http://localhost:8081                        # Local
+APP_DATABASE_URL=libsql://your-db.turso.io?authToken=token    # Cloud
+```
+
+## Connection Pooling
+
+### PostgreSQL
+
+Configurable pool settings for concurrent access:
+
+```go
+db.SetMaxOpenConns(cfg.MaxOpenConns)       // default: 25
+db.SetMaxIdleConns(cfg.MaxIdleConns)       // default: 5
+db.SetConnMaxIdleTime(cfg.ConnMaxIdleTime) // default: 5m
+db.SetConnMaxLifetime(cfg.ConnMaxLifetime) // default: 1h
+```
+
+### SQLite
+
+Single connection with WAL mode for consistency:
+
+```go
+db.SetMaxOpenConns(1)
+db.SetMaxIdleConns(1)
+```
+
+```sql
+PRAGMA journal_mode=WAL
+```
+
+## Local Development
+
+**PostgreSQL:**
+
+```bash
+docker compose up -d postgres
+make migrate-up
+make dev
+```
+
+**SQLite3:**
+
+```bash
+mkdir -p data
+make migrate-up
+make dev
+```
+
+## Production
+
+### PostgreSQL
+
+- Use managed services (AWS RDS, Cloud SQL)
+- Enable SSL: `sslmode=require`
+- Consider PgBouncer for high traffic
+
+### SQLite3
+
+- Use persistent volumes
+- Enable Litestream for backups
+- Single instance only
+
+## Health Checks
+
+The `/health` endpoint verifies database connectivity:
+
+```json
+{"status": "ok", "database": "ok", "timestamp": "2024-01-15T10:30:00Z"}
+```

--- a/website/docs/guides/database-troubleshooting.md
+++ b/website/docs/guides/database-troubleshooting.md
@@ -1,0 +1,142 @@
+# Database Troubleshooting
+
+Common issues and solutions for Tracks database operations.
+
+## Connection Issues
+
+### Connection Refused
+
+```bash
+# PostgreSQL - check if running
+docker compose ps
+docker compose up -d postgres
+
+# SQLite - check data directory
+mkdir -p data
+```
+
+### Authentication Failed
+
+Verify credentials match between `.env` and `docker-compose.yml`:
+
+```bash
+APP_DATABASE_URL=postgres://postgres:postgres@localhost:5432/myapp?sslmode=disable
+```
+
+### Database Does Not Exist
+
+```bash
+docker compose exec postgres createdb -U postgres myapp
+```
+
+## Migration Issues
+
+### Dirty Database
+
+Migration failed midway. Check status and manually fix:
+
+```bash
+tracks db status
+```
+
+```sql
+SELECT * FROM goose_db_version ORDER BY id DESC LIMIT 5;
+UPDATE goose_db_version SET is_applied = true WHERE version_id = <version>;
+```
+
+### No Migration Files Found
+
+```bash
+ls -la internal/db/migrations/
+```
+
+## SQLite Issues
+
+### Database Is Locked
+
+Multiple processes trying to write. Tracks mitigates this with:
+
+```go
+db.SetMaxOpenConns(1)  // Single connection
+```
+
+```sql
+PRAGMA journal_mode=WAL;    -- Better concurrency
+PRAGMA busy_timeout=5000;   -- Wait before failing
+```
+
+### Disk I/O Error
+
+```bash
+df -h data/                                    # Check disk space
+sqlite3 data/myapp.db "PRAGMA integrity_check" # Check integrity
+```
+
+### Large WAL File
+
+```sql
+PRAGMA wal_checkpoint(TRUNCATE);
+```
+
+## PostgreSQL Issues
+
+### Too Many Connections
+
+```bash
+APP_DATABASE_MAX_OPEN_CONNS=10  # Reduce pool size
+```
+
+```sql
+SELECT count(*) FROM pg_stat_activity WHERE datname = 'myapp';
+```
+
+### Slow Queries
+
+```sql
+-- Enable logging
+ALTER SYSTEM SET log_min_duration_statement = 1000;
+SELECT pg_reload_conf();
+
+-- Check for missing indexes
+EXPLAIN ANALYZE SELECT * FROM users WHERE email = 'test@example.com';
+```
+
+### Connection Timeout
+
+```bash
+APP_DATABASE_CONNECT_TIMEOUT=30s
+```
+
+## SQLC Issues
+
+### Column Does Not Exist
+
+Query references a column not in schema:
+
+```bash
+make migrate-up  # Apply pending migrations
+make generate    # Regenerate SQLC
+```
+
+### Type Mismatch
+
+Add overrides in `sqlc.yaml`:
+
+```yaml
+gen:
+  go:
+    overrides:
+      - db_type: "text"
+        go_type: "string"
+```
+
+## Health Check Failing
+
+```bash
+# Check logs
+docker compose logs app
+
+# Test connectivity
+psql $APP_DATABASE_URL -c "SELECT 1"
+sqlite3 data/myapp.db "SELECT 1"
+```

--- a/website/docs/guides/database-troubleshooting.md
+++ b/website/docs/guides/database-troubleshooting.md
@@ -50,19 +50,16 @@ UPDATE goose_db_version SET is_applied = true WHERE version_id = <version>;
 ls -la internal/db/migrations/
 ```
 
-## SQLite Issues
+## SQLite3 Issues
 
 ### Database Is Locked
 
-Multiple processes trying to write. Tracks mitigates this with:
+Multiple processes trying to write. Tracks mitigates this with single-connection mode and WAL (enabled automatically).
 
-```go
-db.SetMaxOpenConns(1)  // Single connection
-```
+If still experiencing locks, add busy timeout:
 
 ```sql
-PRAGMA journal_mode=WAL;    -- Better concurrency
-PRAGMA busy_timeout=5000;   -- Wait before failing
+PRAGMA busy_timeout=5000;   -- Wait 5s before failing
 ```
 
 ### Disk I/O Error

--- a/website/docs/guides/migrations.md
+++ b/website/docs/guides/migrations.md
@@ -1,0 +1,107 @@
+# Migrations
+
+Manage database schema changes with [Goose](https://github.com/pressly/goose) migrations.
+
+## Directory Structure
+
+```text
+internal/db/
+├── migrations/         # SQL migration files
+├── queries/            # SQLC query files
+└── generated/          # SQLC generated code
+```
+
+## Creating Migrations
+
+```bash
+make migrate-create NAME=add_posts_table
+```
+
+Creates: `internal/db/migrations/20240115143022_add_posts_table.sql`
+
+### File Format
+
+```sql
+-- +goose Up
+CREATE TABLE posts (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    author_id TEXT NOT NULL REFERENCES users(id),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS posts;
+```
+
+## Running Migrations
+
+**Make targets:**
+
+```bash
+make migrate-up       # Apply pending
+make migrate-down     # Roll back last
+make migrate-status   # Check status
+```
+
+**CLI (PostgreSQL only):**
+
+```bash
+tracks db migrate            # Apply pending
+tracks db migrate --dry-run  # Preview
+tracks db rollback           # Roll back last
+tracks db status             # Check status
+tracks db reset --force      # Reset database
+```
+
+## Best Practices
+
+**Always include down migrations:**
+
+```sql
+-- +goose Up
+ALTER TABLE users ADD COLUMN bio TEXT;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN bio;
+```
+
+**Use idempotent statements:**
+
+```sql
+CREATE TABLE IF NOT EXISTS posts (...);
+DROP TABLE IF EXISTS posts;
+```
+
+**One change per migration** - keep migrations focused on a single logical change.
+
+**Test both directions** before deploying:
+
+```bash
+make migrate-up && make migrate-down && make migrate-up
+```
+
+## Driver-Specific Notes
+
+### PostgreSQL
+
+- Transactional DDL (atomic schema changes)
+- Supports `CREATE INDEX CONCURRENTLY`
+
+### SQLite
+
+Limited `ALTER TABLE` support. To drop a column, recreate the table:
+
+```sql
+-- +goose Up
+CREATE TABLE posts_new (...);
+INSERT INTO posts_new SELECT ... FROM posts;
+DROP TABLE posts;
+ALTER TABLE posts_new RENAME TO posts;
+```
+
+## Troubleshooting
+
+**Dirty database:** Migration failed midway. Check status, manually fix, then update `goose_db_version` table.
+
+**Order conflicts:** Coordinate timestamps when multiple developers create migrations. Rebase before merging.

--- a/website/docs/guides/sqlc-queries.md
+++ b/website/docs/guides/sqlc-queries.md
@@ -1,0 +1,134 @@
+# SQLC Queries
+
+Write type-safe SQL queries with [SQLC](https://sqlc.dev/).
+
+## Directory Structure
+
+```text
+internal/db/
+├── queries/      # Your SQL query files
+├── generated/    # SQLC output (do not edit)
+└── sqlc.yaml     # Configuration
+```
+
+## Query Annotations
+
+| Annotation | Returns | Use Case |
+|------------|---------|----------|
+| `:one` | Single row or error | Get by ID |
+| `:many` | Slice of rows | List, search |
+| `:exec` | Only error | INSERT, UPDATE, DELETE |
+| `:execrows` | Row count + error | Batch operations |
+
+## Writing Queries
+
+Create `internal/db/queries/users.sql`:
+
+```sql
+-- name: GetUser :one
+SELECT id, email, name FROM users WHERE id = $1;
+
+-- name: ListUsers :many
+SELECT id, email, name FROM users ORDER BY created_at DESC LIMIT $1 OFFSET $2;
+
+-- name: CreateUser :one
+INSERT INTO users (id, email, name) VALUES ($1, $2, $3) RETURNING *;
+
+-- name: UpdateUser :exec
+UPDATE users SET name = $2 WHERE id = $1;
+
+-- name: DeleteUser :exec
+DELETE FROM users WHERE id = $1;
+```
+
+Generate code:
+
+```bash
+make generate
+```
+
+## Using Generated Code
+
+```go
+type UserRepository struct {
+    queries *generated.Queries
+}
+
+func NewUserRepository(db *sql.DB) *UserRepository {
+    return &UserRepository{queries: generated.New(db)}
+}
+
+func (r *UserRepository) GetByID(ctx context.Context, id string) (*User, error) {
+    row, err := r.queries.GetUser(ctx, id)
+    if err != nil {
+        if errors.Is(err, sql.ErrNoRows) {
+            return nil, ErrUserNotFound
+        }
+        return nil, fmt.Errorf("get user: %w", err)
+    }
+    return &User{ID: row.ID, Email: row.Email, Name: row.Name}, nil
+}
+```
+
+### Transactions
+
+```go
+func (r *UserRepository) CreateWithProfile(ctx context.Context, user *User) error {
+    tx, err := r.db.BeginTx(ctx, nil)
+    if err != nil {
+        return err
+    }
+    defer tx.Rollback()
+
+    queries := r.queries.WithTx(tx)
+    // ... use queries ...
+    return tx.Commit()
+}
+```
+
+## Query Patterns
+
+**Nullable fields** use `sql.NullString`, `sql.NullInt64`, etc.
+
+**Dynamic filters:**
+
+```sql
+-- name: SearchUsers :many
+SELECT * FROM users
+WHERE ($1::text IS NULL OR email LIKE '%' || $1 || '%')
+ORDER BY created_at DESC;
+```
+
+## Configuration
+
+The generated `sqlc.yaml`:
+
+```yaml
+version: "2"
+sql:
+  - engine: "postgresql"
+    queries: "queries/"
+    schema: "migrations/"
+    gen:
+      go:
+        package: "generated"
+        out: "generated"
+        emit_json_tags: true
+        emit_empty_slices: true
+```
+
+### Type Overrides
+
+```yaml
+gen:
+  go:
+    overrides:
+      - db_type: "uuid"
+        go_type: "github.com/google/uuid.UUID"
+```
+
+## Best Practices
+
+- Use descriptive names: `GetUserByEmail`, `ListActiveUsers`
+- Organize queries by domain: `users.sql`, `posts.sql`
+- Validate before generating - SQLC checks SQL against your schema

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -24,16 +24,36 @@ const sidebars = {
       type: 'category',
       label: 'Guides',
       items: [
-        'guides/architecture-overview',
-        'guides/example-walkthrough',
-        'guides/layer-guide',
-        'guides/routing-guide',
-        'guides/middleware',
-        'guides/troubleshooting-routing',
-        'guides/patterns',
-        'guides/testing',
-        'guides/development-workflow',
-        'guides/caching',
+        {
+          type: 'category',
+          label: 'Architecture',
+          items: ['guides/architecture-overview', 'guides/layer-guide', 'guides/patterns'],
+        },
+        {
+          type: 'category',
+          label: 'Routing & HTTP',
+          items: ['guides/routing-guide', 'guides/middleware', 'guides/troubleshooting-routing'],
+        },
+        {
+          type: 'category',
+          label: 'Database',
+          items: [
+            'guides/database-setup',
+            'guides/migrations',
+            'guides/sqlc-queries',
+            'guides/database-troubleshooting',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Development',
+          items: [
+            'guides/example-walkthrough',
+            'guides/testing',
+            'guides/development-workflow',
+            'guides/caching',
+          ],
+        },
       ],
     },
     {
@@ -45,7 +65,7 @@ const sidebars = {
         {
           type: 'category',
           label: 'Commands',
-          items: ['cli/commands', 'cli/new', 'cli/version', 'cli/help'],
+          items: ['cli/commands', 'cli/new', 'cli/db', 'cli/version', 'cli/help'],
         },
       ],
     },


### PR DESCRIPTION
## What

Add comprehensive database documentation to the website:
- Database setup guide (drivers, configuration, connection pooling)
- Migrations guide (Goose patterns, CLI commands)
- SQLC queries guide (annotations, patterns, transactions)
- Database troubleshooting guide
- CLI reference for `tracks db` commands

## Why

Phase 2 (Data Layer) needs user-facing documentation for database features. Users need guidance on setup, migrations, queries, and troubleshooting.

## Testing

- [x] Tests pass locally
- [x] Linting passes (`make lint`)
- [x] Docs site builds and renders correctly

## Notes

Also reorganized guides sidebar into subcategories (Architecture, Routing & HTTP, Database, Development) for better navigation.

Closes #534